### PR TITLE
python3 message generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-rapidjson
 pyzmq>=17
 ruamel.yaml
 typing
+dataclasses
 
 # testing
 pytest

--- a/rpcq.asd
+++ b/rpcq.asd
@@ -35,6 +35,7 @@
   :components ((:file "package")
                (:file "utilities")
                (:file "rpcq")
+               (:file "rpcq-python")
                (:file "messages")
                (:file "server")
                (:file "client")))

--- a/rpcq/messages.py
+++ b/rpcq/messages.py
@@ -4,1326 +4,321 @@
 WARNING: This file is auto-generated, do not edit by hand. See README.md.
 """
 
-import warnings
+from warnings import warn
 from rpcq._base import Message
-from typing import List, Dict, Optional
-
-# Python 2/3 str/unicode compatibility
-from past.builtins import basestring
+from dataclasses import dataclass, field, InitVar
+from typing import Any, List, Dict, Optional, Union, Tuple
 
 
-class CoreMessages(object):
-    """
-    WARNING: This class is auto-generated, do not edit by hand. See README.md.
-    This class is also DEPRECATED.
-    """
-
-
-class _deprecated_property(object):
-
-    def __init__(self, prop):
-        self.prop = prop
-
-    def __get__(self, *args):
-        warnings.warn(
-            "'CoreMessages.{0}' is deprecated. Please access '{0}' directly at the module level.".format(
-                self.prop.__name__),
-            UserWarning)
-        return self.prop
-
-
+@dataclass(eq=False, repr=False)
 class ParameterSpec(Message):
-    """Specification of a dynamic parameter type and array-length."""
+    """
+    Specification of a dynamic parameter type and array-length.
+    """
 
-    # fix slots
-    __slots__ = (
-        'type',
-        'length',
-    )
+    type: str = None
+    """The parameter type, e.g., one of 'INTEGER', or 'FLOAT'."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'type': self.type,
-            'length': self.length
-        }
+    length: int = 1
+    """If this is not 1, the parameter is an array of this length."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.type,
-            self.length
-        )
 
-    def __init__(self,
-                 type=None,
-                 length=1,
-                 **kwargs):
-        # type: (str, int) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if type is None:
-            raise ValueError("The field 'type' cannot be None")
-        if length is None:
-            raise ValueError("The field 'length' cannot be None")
-
-        # verify types
-        if not isinstance(type, basestring):
-            raise TypeError("Parameter type must be of type basestring, "
-                            + "but object of type {} given".format(type(type)))
-        if not isinstance(length, int):
-            raise TypeError("Parameter length must be of type int, "
-                            + "but object of type {} given".format(type(length)))
-
-        self.type = type  # type: str
-        """The parameter type, e.g., one of 'INTEGER', or 'FLOAT'."""
-
-        self.length = length  # type: int
-        """If this is not 1, the parameter is an array of this length."""
-
-CoreMessages.ParameterSpec = _deprecated_property(ParameterSpec)
-
+@dataclass(eq=False, repr=False)
 class ParameterAref(Message):
-    """A parametric expression."""
+    """
+    A parametric expression.
+    """
 
-    # fix slots
-    __slots__ = (
-        'name',
-        'index',
-    )
+    name: str
+    """The parameter name"""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'name': self.name,
-            'index': self.index
-        }
+    index: int
+    """The array index."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.name,
-            self.index
-        )
 
-    def __init__(self,
-                 name,
-                 index,
-                 **kwargs):
-        # type: (str, int) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if name is None:
-            raise ValueError("The field 'name' cannot be None")
-        if index is None:
-            raise ValueError("The field 'index' cannot be None")
-
-        # verify types
-        if not isinstance(name, basestring):
-            raise TypeError("Parameter name must be of type basestring, "
-                            + "but object of type {} given".format(type(name)))
-        if not isinstance(index, int):
-            raise TypeError("Parameter index must be of type int, "
-                            + "but object of type {} given".format(type(index)))
-
-        self.name = name  # type: str
-        """The parameter name"""
-
-        self.index = index  # type: int
-        """The array index."""
-
-CoreMessages.ParameterAref = _deprecated_property(ParameterAref)
-
+@dataclass(eq=False, repr=False)
 class PatchTarget(Message):
-    """Patchable memory location descriptor."""
+    """
+    Patchable memory location descriptor.
+    """
 
-    # fix slots
-    __slots__ = (
-        'patch_type',
-        'patch_offset',
-    )
+    patch_type: ParameterSpec
+    """Data type at this address."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'patch_type': self.patch_type,
-            'patch_offset': self.patch_offset
-        }
+    patch_offset: int
+    """Memory address of the patch."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.patch_type,
-            self.patch_offset
-        )
 
-    def __init__(self,
-                 patch_type,
-                 patch_offset,
-                 **kwargs):
-        # type: (ParameterSpec, int) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if patch_type is None:
-            raise ValueError("The field 'patch_type' cannot be None")
-        if patch_offset is None:
-            raise ValueError("The field 'patch_offset' cannot be None")
-
-        # verify types
-        if not isinstance(patch_type, ParameterSpec):
-            raise TypeError("Parameter patch_type must be of type ParameterSpec, "
-                            + "but object of type {} given".format(type(patch_type)))
-        if not isinstance(patch_offset, int):
-            raise TypeError("Parameter patch_offset must be of type int, "
-                            + "but object of type {} given".format(type(patch_offset)))
-
-        self.patch_type = patch_type  # type: ParameterSpec
-        """Data type at this address."""
-
-        self.patch_offset = patch_offset  # type: int
-        """Memory address of the patch."""
-
-CoreMessages.PatchTarget = _deprecated_property(PatchTarget)
-
+@dataclass(eq=False, repr=False)
 class RPCRequest(Message):
-    """A single request object according to the JSONRPC standard."""
+    """
+    A single request object according to the JSONRPC standard.
+    """
 
-    # fix slots
-    __slots__ = (
-        'jsonrpc',
-        'method',
-        'params',
-        'id',
-    )
+    method: str
+    """The RPC function name."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'jsonrpc': self.jsonrpc,
-            'method': self.method,
-            'params': self.params,
-            'id': self.id
-        }
+    params: Any
+    """The RPC function arguments."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.jsonrpc,
-            self.method,
-            self.params,
-            self.id
-        )
+    id: str
+    """RPC request id (used to verify that request and response belong together)."""
 
-    def __init__(self,
-                 method,
-                 params,
-                 id,
-                 jsonrpc="2.0",
-                 **kwargs):
-        # type: (str, object, str, str) -> None
+    jsonrpc: str = "2.0"
+    """The JSONRPC version."""
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
 
-        # check presence of required fields
-        if jsonrpc is None:
-            raise ValueError("The field 'jsonrpc' cannot be None")
-        if method is None:
-            raise ValueError("The field 'method' cannot be None")
-        if params is None:
-            raise ValueError("The field 'params' cannot be None")
-        if id is None:
-            raise ValueError("The field 'id' cannot be None")
-
-        # verify types
-        if not isinstance(jsonrpc, basestring):
-            raise TypeError("Parameter jsonrpc must be of type basestring, "
-                            + "but object of type {} given".format(type(jsonrpc)))
-        if not isinstance(method, basestring):
-            raise TypeError("Parameter method must be of type basestring, "
-                            + "but object of type {} given".format(type(method)))
-        if not isinstance(params, object):
-            raise TypeError("Parameter params must be of type object, "
-                            + "but object of type {} given".format(type(params)))
-        if not isinstance(id, basestring):
-            raise TypeError("Parameter id must be of type basestring, "
-                            + "but object of type {} given".format(type(id)))
-
-        self.jsonrpc = jsonrpc  # type: str
-        """The JSONRPC version."""
-
-        self.method = method  # type: str
-        """The RPC function name."""
-
-        self.params = params  # type: object
-        """The RPC function arguments."""
-
-        self.id = id  # type: str
-        """RPC request id (used to verify that request and response belong together)."""
-
-CoreMessages.RPCRequest = _deprecated_property(RPCRequest)
-
+@dataclass(eq=False, repr=False)
 class RPCReply(Message):
-    """The reply for a JSONRPC request."""
+    """
+    The reply for a JSONRPC request.
+    """
 
-    # fix slots
-    __slots__ = (
-        'jsonrpc',
-        'result',
-        'id',
-    )
+    id: str
+    """The RPC request id."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'jsonrpc': self.jsonrpc,
-            'result': self.result,
-            'id': self.id
-        }
+    jsonrpc: str = "2.0"
+    """The JSONRPC version."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.jsonrpc,
-            self.result,
-            self.id
-        )
+    result: Optional[Any] = None
+    """The RPC result."""
 
-    def __init__(self,
-                 id,
-                 jsonrpc="2.0",
-                 result=None,
-                 **kwargs):
-        # type: (str, str, Optional[object]) -> None
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if jsonrpc is None:
-            raise ValueError("The field 'jsonrpc' cannot be None")
-        if id is None:
-            raise ValueError("The field 'id' cannot be None")
-
-        # verify types
-        if not isinstance(jsonrpc, basestring):
-            raise TypeError("Parameter jsonrpc must be of type basestring, "
-                            + "but object of type {} given".format(type(jsonrpc)))
-        if not (result is None or isinstance(result, object)):
-            raise TypeError("Parameter result must be of type object, "
-                            + "but object of type {} given".format(type(result)))
-        if not isinstance(id, basestring):
-            raise TypeError("Parameter id must be of type basestring, "
-                            + "but object of type {} given".format(type(id)))
-
-        self.jsonrpc = jsonrpc  # type: str
-        """The JSONRPC version."""
-
-        self.result = result  # type: Optional[object]
-        """The RPC result."""
-
-        self.id = id  # type: str
-        """The RPC request id."""
-
-CoreMessages.RPCReply = _deprecated_property(RPCReply)
-
+@dataclass(eq=False, repr=False)
 class RPCError(Message):
-    """A error message for JSONRPC requests."""
+    """
+    A error message for JSONRPC requests.
+    """
 
-    # fix slots
-    __slots__ = (
-        'jsonrpc',
-        'error',
-        'id',
-    )
+    error: str
+    """The error message."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'jsonrpc': self.jsonrpc,
-            'error': self.error,
-            'id': self.id
-        }
+    id: str
+    """The RPC request id."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.jsonrpc,
-            self.error,
-            self.id
-        )
+    jsonrpc: str = "2.0"
+    """The JSONRPC version."""
 
-    def __init__(self,
-                 error,
-                 id,
-                 jsonrpc="2.0",
-                 **kwargs):
-        # type: (str, str, str) -> None
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if jsonrpc is None:
-            raise ValueError("The field 'jsonrpc' cannot be None")
-        if error is None:
-            raise ValueError("The field 'error' cannot be None")
-        if id is None:
-            raise ValueError("The field 'id' cannot be None")
-
-        # verify types
-        if not isinstance(jsonrpc, basestring):
-            raise TypeError("Parameter jsonrpc must be of type basestring, "
-                            + "but object of type {} given".format(type(jsonrpc)))
-        if not isinstance(error, basestring):
-            raise TypeError("Parameter error must be of type basestring, "
-                            + "but object of type {} given".format(type(error)))
-        if not isinstance(id, basestring):
-            raise TypeError("Parameter id must be of type basestring, "
-                            + "but object of type {} given".format(type(id)))
-
-        self.jsonrpc = jsonrpc  # type: str
-        """The JSONRPC version."""
-
-        self.error = error  # type: str
-        """The error message."""
-
-        self.id = id  # type: str
-        """The RPC request id."""
-
-CoreMessages.RPCError = _deprecated_property(RPCError)
-
+@dataclass(eq=False, repr=False)
 class TargetDevice(Message):
-    """ISA and specs for a particular device."""
+    """
+    ISA and specs for a particular device.
+    """
 
-    # fix slots
-    __slots__ = (
-        'isa',
-        'specs',
-    )
+    isa: Dict[str, Dict]
+    """Instruction-set architecture for this device."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'isa': self.isa,
-            'specs': self.specs
-        }
+    specs: Dict[str, Dict]
+    """Fidelities and coherence times for this device."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.isa,
-            self.specs
-        )
 
-    def __init__(self,
-                 isa,
-                 specs,
-                 **kwargs):
-        # type: (Dict[str,dict], Dict[str,dict]) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if isa is None:
-            raise ValueError("The field 'isa' cannot be None")
-        if specs is None:
-            raise ValueError("The field 'specs' cannot be None")
-
-        # verify types
-        if not isinstance(isa, dict):
-            raise TypeError("Parameter isa must be of type dict, "
-                            + "but object of type {} given".format(type(isa)))
-        if not isinstance(specs, dict):
-            raise TypeError("Parameter specs must be of type dict, "
-                            + "but object of type {} given".format(type(specs)))
-
-        self.isa = isa  # type: Dict[str,dict]
-        """Instruction-set architecture for this device."""
-
-        self.specs = specs  # type: Dict[str,dict]
-        """Fidelities and coherence times for this device."""
-
-CoreMessages.TargetDevice = _deprecated_property(TargetDevice)
-
+@dataclass(eq=False, repr=False)
 class RandomizedBenchmarkingRequest(Message):
-    """RPC request payload for generating a randomized benchmarking sequence."""
+    """
+    RPC request payload for generating a randomized benchmarking sequence.
+    """
 
-    # fix slots
-    __slots__ = (
-        'depth',
-        'qubits',
-        'gateset',
-        'seed',
-        'interleaver',
-    )
+    depth: int
+    """Depth of the benchmarking sequence."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'depth': self.depth,
-            'qubits': self.qubits,
-            'gateset': self.gateset,
-            'seed': self.seed,
-            'interleaver': self.interleaver
-        }
+    qubits: int
+    """Number of qubits involved in the benchmarking sequence."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.depth,
-            self.qubits,
-            self.gateset,
-            self.seed,
-            self.interleaver
-        )
+    gateset: List[str]
+    """List of Quil programs, each describing a Clifford."""
 
-    def __init__(self,
-                 depth,
-                 qubits,
-                 gateset,
-                 seed=None,
-                 interleaver=None,
-                 **kwargs):
-        # type: (int, int, List[str], Optional[int], Optional[str]) -> None
+    seed: Optional[int] = None
+    """PRNG seed. Set this to guarantee repeatable results."""
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
+    interleaver: Optional[str] = None
+    """Fixed Clifford, specified as a Quil string, to interleave through an RB sequence."""
 
-        # check presence of required fields
-        if depth is None:
-            raise ValueError("The field 'depth' cannot be None")
-        if qubits is None:
-            raise ValueError("The field 'qubits' cannot be None")
-        if gateset is None:
-            raise ValueError("The field 'gateset' cannot be None")
 
-        # verify types
-        if not isinstance(depth, int):
-            raise TypeError("Parameter depth must be of type int, "
-                            + "but object of type {} given".format(type(depth)))
-        if not isinstance(qubits, int):
-            raise TypeError("Parameter qubits must be of type int, "
-                            + "but object of type {} given".format(type(qubits)))
-        if not isinstance(gateset, list):
-            raise TypeError("Parameter gateset must be of type list, "
-                            + "but object of type {} given".format(type(gateset)))
-        if not (seed is None or isinstance(seed, int)):
-            raise TypeError("Parameter seed must be of type int, "
-                            + "but object of type {} given".format(type(seed)))
-        if not (interleaver is None or isinstance(interleaver, basestring)):
-            raise TypeError("Parameter interleaver must be of type basestring, "
-                            + "but object of type {} given".format(type(interleaver)))
-
-        self.depth = depth  # type: int
-        """Depth of the benchmarking sequence."""
-
-        self.qubits = qubits  # type: int
-        """Number of qubits involved in the benchmarking sequence."""
-
-        self.gateset = gateset  # type: List[str]
-        """List of Quil programs, each describing a Clifford."""
-
-        self.seed = seed  # type: Optional[int]
-        """PRNG seed. Set this to guarantee repeatable results."""
-
-        self.interleaver = interleaver  # type: Optional[str]
-        """Fixed Clifford, specified as a Quil string, to interleave through an RB sequence."""
-
-CoreMessages.RandomizedBenchmarkingRequest = _deprecated_property(RandomizedBenchmarkingRequest)
-
+@dataclass(eq=False, repr=False)
 class RandomizedBenchmarkingResponse(Message):
-    """RPC reply payload for a randomly generated benchmarking sequence."""
+    """
+    RPC reply payload for a randomly generated benchmarking sequence.
+    """
 
-    # fix slots
-    __slots__ = (
-        'sequence',
-    )
+    sequence: List[List[int]]
+    """List of Cliffords, each expressed as a list of generator indices."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'sequence': self.sequence
-        }
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.sequence
-        )
-
-    def __init__(self,
-                 sequence,
-                 **kwargs):
-        # type: (List[List[int]]) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if sequence is None:
-            raise ValueError("The field 'sequence' cannot be None")
-
-        # verify types
-        if not isinstance(sequence, list):
-            raise TypeError("Parameter sequence must be of type list, "
-                            + "but object of type {} given".format(type(sequence)))
-
-        self.sequence = sequence  # type: List[List[int]]
-        """List of Cliffords, each expressed as a list of generator indices."""
-
-CoreMessages.RandomizedBenchmarkingResponse = _deprecated_property(RandomizedBenchmarkingResponse)
-
+@dataclass(eq=False, repr=False)
 class PauliTerm(Message):
-    """Specification of a single Pauli term as a tensor product of Pauli factors."""
+    """
+    Specification of a single Pauli term as a tensor product of Pauli factors.
+    """
 
-    # fix slots
-    __slots__ = (
-        'indices',
-        'symbols',
-    )
+    indices: List[int]
+    """Qubit indices onto which the factors of a Pauli term are applied."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'indices': self.indices,
-            'symbols': self.symbols
-        }
+    symbols: List[str]
+    """Ordered factors of a Pauli term."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.indices,
-            self.symbols
-        )
 
-    def __init__(self,
-                 indices,
-                 symbols,
-                 **kwargs):
-        # type: (List[int], List[str]) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if indices is None:
-            raise ValueError("The field 'indices' cannot be None")
-        if symbols is None:
-            raise ValueError("The field 'symbols' cannot be None")
-
-        # verify types
-        if not isinstance(indices, list):
-            raise TypeError("Parameter indices must be of type list, "
-                            + "but object of type {} given".format(type(indices)))
-        if not isinstance(symbols, list):
-            raise TypeError("Parameter symbols must be of type list, "
-                            + "but object of type {} given".format(type(symbols)))
-
-        self.indices = indices  # type: List[int]
-        """Qubit indices onto which the factors of a Pauli term are applied."""
-
-        self.symbols = symbols  # type: List[str]
-        """Ordered factors of a Pauli term."""
-
-CoreMessages.PauliTerm = _deprecated_property(PauliTerm)
-
+@dataclass(eq=False, repr=False)
 class ConjugateByCliffordRequest(Message):
-    """RPC request payload for conjugating a Pauli element by a Clifford element."""
+    """
+    RPC request payload for conjugating a Pauli element by a Clifford element.
+    """
 
-    # fix slots
-    __slots__ = (
-        'pauli',
-        'clifford',
-    )
+    pauli: PauliTerm
+    """Specification of a Pauli element."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'pauli': self.pauli,
-            'clifford': self.clifford
-        }
+    clifford: str
+    """Specification of a Clifford element."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.pauli,
-            self.clifford
-        )
 
-    def __init__(self,
-                 pauli,
-                 clifford,
-                 **kwargs):
-        # type: (PauliTerm, str) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if pauli is None:
-            raise ValueError("The field 'pauli' cannot be None")
-        if clifford is None:
-            raise ValueError("The field 'clifford' cannot be None")
-
-        # verify types
-        if not isinstance(pauli, PauliTerm):
-            raise TypeError("Parameter pauli must be of type PauliTerm, "
-                            + "but object of type {} given".format(type(pauli)))
-        if not isinstance(clifford, basestring):
-            raise TypeError("Parameter clifford must be of type basestring, "
-                            + "but object of type {} given".format(type(clifford)))
-
-        self.pauli = pauli  # type: PauliTerm
-        """Specification of a Pauli element."""
-
-        self.clifford = clifford  # type: str
-        """Specification of a Clifford element."""
-
-CoreMessages.ConjugateByCliffordRequest = _deprecated_property(ConjugateByCliffordRequest)
-
+@dataclass(eq=False, repr=False)
 class ConjugateByCliffordResponse(Message):
-    """RPC reply payload for a Pauli element as conjugated by a Clifford element."""
+    """
+    RPC reply payload for a Pauli element as conjugated by a Clifford element.
+    """
 
-    # fix slots
-    __slots__ = (
-        'phase',
-        'pauli',
-    )
+    phase: int
+    """Encoded global phase factor on the emitted Pauli."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'phase': self.phase,
-            'pauli': self.pauli
-        }
+    pauli: str
+    """Description of the encoded Pauli."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.phase,
-            self.pauli
-        )
 
-    def __init__(self,
-                 phase,
-                 pauli,
-                 **kwargs):
-        # type: (int, str) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if phase is None:
-            raise ValueError("The field 'phase' cannot be None")
-        if pauli is None:
-            raise ValueError("The field 'pauli' cannot be None")
-
-        # verify types
-        if not isinstance(phase, int):
-            raise TypeError("Parameter phase must be of type int, "
-                            + "but object of type {} given".format(type(phase)))
-        if not isinstance(pauli, basestring):
-            raise TypeError("Parameter pauli must be of type basestring, "
-                            + "but object of type {} given".format(type(pauli)))
-
-        self.phase = phase  # type: int
-        """Encoded global phase factor on the emitted Pauli."""
-
-        self.pauli = pauli  # type: str
-        """Description of the encoded Pauli."""
-
-CoreMessages.ConjugateByCliffordResponse = _deprecated_property(ConjugateByCliffordResponse)
-
+@dataclass(eq=False, repr=False)
 class NativeQuilRequest(Message):
-    """Quil and the device metadata necessary for quilc."""
+    """
+    Quil and the device metadata necessary for quilc.
+    """
 
-    # fix slots
-    __slots__ = (
-        'quil',
-        'target_device',
-    )
+    quil: str
+    """Arbitrary Quil to be sent to quilc."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'quil': self.quil,
-            'target_device': self.target_device
-        }
+    target_device: TargetDevice
+    """Specifications for the device to target with quilc."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.quil,
-            self.target_device
-        )
 
-    def __init__(self,
-                 quil,
-                 target_device,
-                 **kwargs):
-        # type: (str, TargetDevice) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if quil is None:
-            raise ValueError("The field 'quil' cannot be None")
-        if target_device is None:
-            raise ValueError("The field 'target_device' cannot be None")
-
-        # verify types
-        if not isinstance(quil, basestring):
-            raise TypeError("Parameter quil must be of type basestring, "
-                            + "but object of type {} given".format(type(quil)))
-        if not isinstance(target_device, TargetDevice):
-            raise TypeError("Parameter target_device must be of type TargetDevice, "
-                            + "but object of type {} given".format(type(target_device)))
-
-        self.quil = quil  # type: str
-        """Arbitrary Quil to be sent to quilc."""
-
-        self.target_device = target_device  # type: TargetDevice
-        """Specifications for the device to target with quilc."""
-
-CoreMessages.NativeQuilRequest = _deprecated_property(NativeQuilRequest)
-
+@dataclass(eq=False, repr=False)
 class NativeQuilMetadata(Message):
-    """Metadata for a native quil program."""
+    """
+    Metadata for a native quil program.
+    """
 
-    # fix slots
-    __slots__ = (
-        'final_rewiring',
-        'gate_depth',
-        'gate_volume',
-        'multiqubit_gate_depth',
-        'program_duration',
-        'program_fidelity',
-        'topological_swaps',
-    )
+    final_rewiring: List[int] = field(default_factory=list)
+    """Output qubit index relabeling due to SWAP insertion."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'final_rewiring': self.final_rewiring,
-            'gate_depth': self.gate_depth,
-            'gate_volume': self.gate_volume,
-            'multiqubit_gate_depth': self.multiqubit_gate_depth,
-            'program_duration': self.program_duration,
-            'program_fidelity': self.program_fidelity,
-            'topological_swaps': self.topological_swaps
-        }
+    gate_depth: Optional[int] = None
+    """Maximum number of successive gates in the native quil program."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.final_rewiring,
-            self.gate_depth,
-            self.gate_volume,
-            self.multiqubit_gate_depth,
-            self.program_duration,
-            self.program_fidelity,
-            self.topological_swaps
-        )
+    gate_volume: Optional[int] = None
+    """Total number of gates in the native quil program."""
 
-    def __init__(self,
-                 final_rewiring=None,
-                 gate_depth=None,
-                 gate_volume=None,
-                 multiqubit_gate_depth=None,
-                 program_duration=None,
-                 program_fidelity=None,
-                 topological_swaps=None,
-                 **kwargs):
-        # type: (List[int], Optional[int], Optional[int], Optional[int], Optional[float], Optional[float], Optional[int]) -> None
+    multiqubit_gate_depth: Optional[int] = None
+    """Maximum number of successive two-qubit gates in the native quil program."""
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
+    program_duration: Optional[float] = None
+    """Rough estimate of native quil program length in nanoseconds."""
 
-        # initialize default values of collections
-        if final_rewiring is None:
-            final_rewiring = []
+    program_fidelity: Optional[float] = None
+    """Rough estimate of the fidelity of the full native quil program, uses specs."""
 
-        # verify types
-        if not (final_rewiring is None or isinstance(final_rewiring, list)):
-            raise TypeError("Parameter final_rewiring must be of type list, "
-                            + "but object of type {} given".format(type(final_rewiring)))
-        if not (gate_depth is None or isinstance(gate_depth, int)):
-            raise TypeError("Parameter gate_depth must be of type int, "
-                            + "but object of type {} given".format(type(gate_depth)))
-        if not (gate_volume is None or isinstance(gate_volume, int)):
-            raise TypeError("Parameter gate_volume must be of type int, "
-                            + "but object of type {} given".format(type(gate_volume)))
-        if not (multiqubit_gate_depth is None or isinstance(multiqubit_gate_depth, int)):
-            raise TypeError("Parameter multiqubit_gate_depth must be of type int, "
-                            + "but object of type {} given".format(type(multiqubit_gate_depth)))
-        if not (program_duration is None or isinstance(program_duration, float)):
-            raise TypeError("Parameter program_duration must be of type float, "
-                            + "but object of type {} given".format(type(program_duration)))
-        if not (program_fidelity is None or isinstance(program_fidelity, float)):
-            raise TypeError("Parameter program_fidelity must be of type float, "
-                            + "but object of type {} given".format(type(program_fidelity)))
-        if not (topological_swaps is None or isinstance(topological_swaps, int)):
-            raise TypeError("Parameter topological_swaps must be of type int, "
-                            + "but object of type {} given".format(type(topological_swaps)))
+    topological_swaps: Optional[int] = None
+    """Total number of SWAPs in the native quil program."""
 
-        self.final_rewiring = final_rewiring  # type: List[int]
-        """Output qubit index relabeling due to SWAP insertion."""
 
-        self.gate_depth = gate_depth  # type: Optional[int]
-        """Maximum number of successive gates in the native quil program."""
-
-        self.gate_volume = gate_volume  # type: Optional[int]
-        """Total number of gates in the native quil program."""
-
-        self.multiqubit_gate_depth = multiqubit_gate_depth  # type: Optional[int]
-        """Maximum number of successive two-qubit gates in the native quil program."""
-
-        self.program_duration = program_duration  # type: Optional[float]
-        """Rough estimate of native quil program length in nanoseconds."""
-
-        self.program_fidelity = program_fidelity  # type: Optional[float]
-        """Rough estimate of the fidelity of the full native quil program, uses specs."""
-
-        self.topological_swaps = topological_swaps  # type: Optional[int]
-        """Total number of SWAPs in the native quil program."""
-
-CoreMessages.NativeQuilMetadata = _deprecated_property(NativeQuilMetadata)
-
+@dataclass(eq=False, repr=False)
 class NativeQuilResponse(Message):
-    """Native Quil and associated metadata returned from quilc."""
+    """
+    Native Quil and associated metadata returned from quilc.
+    """
 
-    # fix slots
-    __slots__ = (
-        'quil',
-        'metadata',
-    )
+    quil: str
+    """Native Quil returned from quilc."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'quil': self.quil,
-            'metadata': self.metadata
-        }
+    metadata: Optional[NativeQuilMetadata] = None
+    """Metadata for the returned Native Quil."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.quil,
-            self.metadata
-        )
 
-    def __init__(self,
-                 quil,
-                 metadata=None,
-                 **kwargs):
-        # type: (str, Optional[NativeQuilMetadata]) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if quil is None:
-            raise ValueError("The field 'quil' cannot be None")
-
-        # verify types
-        if not isinstance(quil, basestring):
-            raise TypeError("Parameter quil must be of type basestring, "
-                            + "but object of type {} given".format(type(quil)))
-        if not (metadata is None or isinstance(metadata, NativeQuilMetadata)):
-            raise TypeError("Parameter metadata must be of type NativeQuilMetadata, "
-                            + "but object of type {} given".format(type(metadata)))
-
-        self.quil = quil  # type: str
-        """Native Quil returned from quilc."""
-
-        self.metadata = metadata  # type: Optional[NativeQuilMetadata]
-        """Metadata for the returned Native Quil."""
-
-CoreMessages.NativeQuilResponse = _deprecated_property(NativeQuilResponse)
-
+@dataclass(eq=False, repr=False)
 class RewriteArithmeticRequest(Message):
-    """A request type to handle compiling arithmetic out of gate parameters."""
+    """
+    A request type to handle compiling arithmetic out of gate parameters.
+    """
 
-    # fix slots
-    __slots__ = (
-        'quil',
-    )
+    quil: str
+    """Native Quil for which to rewrite arithmetic parameters."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'quil': self.quil
-        }
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.quil
-        )
-
-    def __init__(self,
-                 quil,
-                 **kwargs):
-        # type: (str) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if quil is None:
-            raise ValueError("The field 'quil' cannot be None")
-
-        # verify types
-        if not isinstance(quil, basestring):
-            raise TypeError("Parameter quil must be of type basestring, "
-                            + "but object of type {} given".format(type(quil)))
-
-        self.quil = quil  # type: str
-        """Native Quil for which to rewrite arithmetic parameters."""
-
-CoreMessages.RewriteArithmeticRequest = _deprecated_property(RewriteArithmeticRequest)
-
+@dataclass(eq=False, repr=False)
 class RewriteArithmeticResponse(Message):
-    """The data needed to run programs with gate arithmetic on the hardware."""
+    """
+    The data needed to run programs with gate arithmetic on the hardware.
+    """
 
-    # fix slots
-    __slots__ = (
-        'quil',
-        'original_memory_descriptors',
-        'recalculation_table',
-    )
+    quil: str
+    """Native Quil rewritten with no arithmetic in gate parameters."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'quil': self.quil,
-            'original_memory_descriptors': self.original_memory_descriptors,
-            'recalculation_table': self.recalculation_table
-        }
+    original_memory_descriptors: Dict[str, ParameterSpec] = field(default_factory=dict)
+    """The declared memory descriptors in the Quil of the related request."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.quil,
-            self.original_memory_descriptors,
-            self.recalculation_table
-        )
+    recalculation_table: Dict[ParameterAref, str] = field(default_factory=dict)
+    """A mapping from memory references to the original gate arithmetic."""
 
-    def __init__(self,
-                 quil,
-                 original_memory_descriptors=None,
-                 recalculation_table=None,
-                 **kwargs):
-        # type: (str, Dict[str,ParameterSpec], Dict[ParameterAref,str]) -> None
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # initialize default values of collections
-        if original_memory_descriptors is None:
-            original_memory_descriptors = {}
-        if recalculation_table is None:
-            recalculation_table = {}
-
-        # check presence of required fields
-        if quil is None:
-            raise ValueError("The field 'quil' cannot be None")
-
-        # verify types
-        if not isinstance(quil, basestring):
-            raise TypeError("Parameter quil must be of type basestring, "
-                            + "but object of type {} given".format(type(quil)))
-        if not (original_memory_descriptors is None or isinstance(original_memory_descriptors, dict)):
-            raise TypeError("Parameter original_memory_descriptors must be of type dict, "
-                            + "but object of type {} given".format(type(original_memory_descriptors)))
-        if not (recalculation_table is None or isinstance(recalculation_table, dict)):
-            raise TypeError("Parameter recalculation_table must be of type dict, "
-                            + "but object of type {} given".format(type(recalculation_table)))
-
-        self.quil = quil  # type: str
-        """Native Quil rewritten with no arithmetic in gate parameters."""
-
-        self.original_memory_descriptors = original_memory_descriptors  # type: Dict[str,ParameterSpec]
-        """The declared memory descriptors in the Quil of the related request."""
-
-        self.recalculation_table = recalculation_table  # type: Dict[ParameterAref,str]
-        """A mapping from memory references to the original gate arithmetic."""
-
-CoreMessages.RewriteArithmeticResponse = _deprecated_property(RewriteArithmeticResponse)
-
+@dataclass(eq=False, repr=False)
 class BinaryExecutableRequest(Message):
-    """Native Quil and the information needed to create binary executables."""
+    """
+    Native Quil and the information needed to create binary executables.
+    """
 
-    # fix slots
-    __slots__ = (
-        'quil',
-        'num_shots',
-    )
+    quil: str
+    """Native Quil to be translated into an executable program."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'quil': self.quil,
-            'num_shots': self.num_shots
-        }
+    num_shots: int
+    """The number of times to repeat the program."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.quil,
-            self.num_shots
-        )
 
-    def __init__(self,
-                 quil,
-                 num_shots,
-                 **kwargs):
-        # type: (str, int) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if quil is None:
-            raise ValueError("The field 'quil' cannot be None")
-        if num_shots is None:
-            raise ValueError("The field 'num_shots' cannot be None")
-
-        # verify types
-        if not isinstance(quil, basestring):
-            raise TypeError("Parameter quil must be of type basestring, "
-                            + "but object of type {} given".format(type(quil)))
-        if not isinstance(num_shots, int):
-            raise TypeError("Parameter num_shots must be of type int, "
-                            + "but object of type {} given".format(type(num_shots)))
-
-        self.quil = quil  # type: str
-        """Native Quil to be translated into an executable program."""
-
-        self.num_shots = num_shots  # type: int
-        """The number of times to repeat the program."""
-
-CoreMessages.BinaryExecutableRequest = _deprecated_property(BinaryExecutableRequest)
-
+@dataclass(eq=False, repr=False)
 class BinaryExecutableResponse(Message):
-    """Program to run on the QPU."""
+    """
+    Program to run on the QPU.
+    """
 
-    # fix slots
-    __slots__ = (
-        'program',
-        'memory_descriptors',
-        'recalculation_table',
-        'ro_sources',
-    )
+    program: str
+    """Execution settings and sequencer binaries."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'program': self.program,
-            'memory_descriptors': self.memory_descriptors,
-            'ro_sources': self.ro_sources
-        }
+    memory_descriptors: Dict[str, ParameterSpec] = field(default_factory=dict)
+    """Internal field for constructing patch tables."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.program,
-            self.memory_descriptors,
-            self.ro_sources
-        )
+    ro_sources: List[Any] = field(default_factory=list)
+    """Internal field for reshaping returned buffers."""
 
-    def __init__(self,
-                 program,
-                 memory_descriptors=None,
-                 ro_sources=None,
-                 **kwargs):
-        # type: (str, Dict[str,ParameterSpec], List[object]) -> None
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # initialize default values of collections
-        if memory_descriptors is None:
-            memory_descriptors = {}
-        if ro_sources is None:
-            ro_sources = []
-
-        # check presence of required fields
-        if program is None:
-            raise ValueError("The field 'program' cannot be None")
-
-        # verify types
-        if not isinstance(program, basestring):
-            raise TypeError("Parameter program must be of type basestring, "
-                            + "but object of type {} given".format(type(program)))
-        if not (memory_descriptors is None or isinstance(memory_descriptors, dict)):
-            raise TypeError("Parameter memory_descriptors must be of type dict, "
-                            + "but object of type {} given".format(type(memory_descriptors)))
-        if not (ro_sources is None or isinstance(ro_sources, list)):
-            raise TypeError("Parameter ro_sources must be of type list, "
-                            + "but object of type {} given".format(type(ro_sources)))
-
-        self.program = program  # type: str
-        """Execution settings and sequencer binaries."""
-
-        self.memory_descriptors = memory_descriptors  # type: Dict[str,ParameterSpec]
-        """Internal field for constructing patch tables."""
-
-        self.ro_sources = ro_sources  # type: List[object]
-        """Internal field for reshaping returned buffers."""
-
-CoreMessages.BinaryExecutableResponse = _deprecated_property(BinaryExecutableResponse)
-
+@dataclass(eq=False, repr=False)
 class PyQuilExecutableResponse(Message):
-    """rpcQ-serializable form of a pyQuil Program object."""
+    """
+    rpcQ-serializable form of a pyQuil Program object.
+    """
 
-    # fix slots
-    __slots__ = (
-        'program',
-        'attributes',
-    )
+    program: str
+    """String representation of a Quil program."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'program': self.program,
-            'attributes': self.attributes
-        }
+    attributes: Dict[str, Any]
+    """Miscellaneous attributes to be unpacked onto the pyQuil Program object."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.program,
-            self.attributes
-        )
 
-    def __init__(self,
-                 program,
-                 attributes,
-                 **kwargs):
-        # type: (str, Dict[str,object]) -> None
-
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if program is None:
-            raise ValueError("The field 'program' cannot be None")
-        if attributes is None:
-            raise ValueError("The field 'attributes' cannot be None")
-
-        # verify types
-        if not isinstance(program, basestring):
-            raise TypeError("Parameter program must be of type basestring, "
-                            + "but object of type {} given".format(type(program)))
-        if not isinstance(attributes, dict):
-            raise TypeError("Parameter attributes must be of type dict, "
-                            + "but object of type {} given".format(type(attributes)))
-
-        self.program = program  # type: str
-        """String representation of a Quil program."""
-
-        self.attributes = attributes  # type: Dict[str,object]
-        """Miscellaneous attributes to be unpacked onto the pyQuil Program object."""
-
-CoreMessages.PyQuilExecutableResponse = _deprecated_property(PyQuilExecutableResponse)
-
+@dataclass(eq=False, repr=False)
 class QPURequest(Message):
-    """Program and patch values to send to the QPU for execution."""
+    """
+    Program and patch values to send to the QPU for execution.
+    """
 
-    # fix slots
-    __slots__ = (
-        'program',
-        'patch_values',
-        'id',
-    )
+    program: Any
+    """Execution settings and sequencer binaries."""
 
-    def asdict(self):
-        """Generate dictionary representation of self."""
-        return {
-            'program': self.program,
-            'patch_values': self.patch_values,
-            'id': self.id
-        }
+    patch_values: Dict[str, List[Any]]
+    """Dictionary mapping data names to data values for patching the binary."""
 
-    def astuple(self):
-        """Generate tuple representation of self."""
-        return (
-            self.program,
-            self.patch_values,
-            self.id
-        )
+    id: str
+    """QPU request ID."""
 
-    def __init__(self,
-                 program,
-                 patch_values,
-                 id,
-                 **kwargs):
-        # type: (object, Dict[str,List[object]], str) -> None
 
-        if kwargs:
-            warnings.warn(("Message {} ignoring unexpected keyword arguments: "
-                    "{}.").format(self.__class__.__name__, ", ".join(kwargs.keys())))
-
-        # check presence of required fields
-        if program is None:
-            raise ValueError("The field 'program' cannot be None")
-        if patch_values is None:
-            raise ValueError("The field 'patch_values' cannot be None")
-        if id is None:
-            raise ValueError("The field 'id' cannot be None")
-
-        # verify types
-        if not isinstance(program, object):
-            raise TypeError("Parameter program must be of type object, "
-                            + "but object of type {} given".format(type(program)))
-        if not isinstance(patch_values, dict):
-            raise TypeError("Parameter patch_values must be of type dict, "
-                            + "but object of type {} given".format(type(patch_values)))
-        if not isinstance(id, basestring):
-            raise TypeError("Parameter id must be of type basestring, "
-                            + "but object of type {} given".format(type(id)))
-
-        self.program = program  # type: object
-        """Execution settings and sequencer binaries."""
-
-        self.patch_values = patch_values  # type: Dict[str,List[object]]
-        """Dictionary mapping data names to data values for patching the binary."""
-
-        self.id = id  # type: str
-        """QPU request ID."""
-
-CoreMessages.QPURequest = _deprecated_property(QPURequest)

--- a/rpcq/test/test_base.py
+++ b/rpcq/test/test_base.py
@@ -17,76 +17,15 @@ from __future__ import print_function
 import logging
 
 import pytest
-from rpcq._base import (Message)
+from rpcq.messages import (RPCError)
 
 log = logging.getLogger(__file__)
 
 
 def test_messages():
-
-    class TestRPCError(Message):
-        """A error message for JSONRPC requests."""
-
-        # fix slots
-        __slots__ = (
-            'jsonrpc',
-            'error',
-            'id',
-        )
-
-        def asdict(self):
-            """Generate dictionary representation of self."""
-            return {
-                'jsonrpc': self.jsonrpc,
-                'error': self.error,
-                'id': self.id
-            }
-
-        def astuple(self):
-            """Generate tuple representation of self."""
-            return (
-                self.jsonrpc,
-                self.error,
-                self.id
-            )
-
-        def __init__(self,
-                     error,
-                     id,
-                     jsonrpc="2.0"):
-            # type: (str, str, str) -> None
-
-            # check presence of required fields
-            if jsonrpc is None:
-                raise ValueError("The field 'jsonrpc' cannot be None")
-            if error is None:
-                raise ValueError("The field 'error' cannot be None")
-            if id is None:
-                raise ValueError("The field 'id' cannot be None")
-
-            # verify types
-            if not isinstance(jsonrpc, str):
-                raise TypeError("Parameter jsonrpc must be of type str, "
-                                + "but object of type {} given".format(type(jsonrpc)))
-            if not isinstance(error, str):
-                raise TypeError("Parameter error must be of type str, "
-                                + "but object of type {} given".format(type(error)))
-            if not isinstance(id, str):
-                raise TypeError("Parameter id must be of type str, "
-                                + "but object of type {} given".format(type(id)))
-
-            self.jsonrpc = jsonrpc  # type: str
-            """The JSONRPC version."""
-
-            self.error = error  # type: str
-            """The error message."""
-
-            self.id = id  # type: str
-            """The RPC request id."""
-
     e = "Error"
     i = "asefa32423"
-    m = TestRPCError(e, id=i)
+    m = RPCError(error=e, id=i)
     assert m.error == e
     assert m.id == i
     assert m.jsonrpc == "2.0"
@@ -97,7 +36,6 @@ def test_messages():
     assert m.asdict() == {"error": e,
                         "id": i,
                         "jsonrpc": "2.0"}
-    assert m.astuple() == ("2.0", e, i)
 
     with pytest.raises(TypeError):
-        TestRPCError(bad_field=1)
+        RPCError(bad_field=1)

--- a/src/messages.lisp
+++ b/src/messages.lisp
@@ -18,7 +18,7 @@
 (in-package #:rpcq)
 
 
-(defmessage |ParameterSpec|
+(defmessage |ParameterSpec| ()
     (
      (|type|
       :documentation "The parameter type, e.g., one of 'INTEGER', or 'FLOAT'."
@@ -34,7 +34,7 @@
      )
   :documentation "Specification of a dynamic parameter type and array-length.")
 
-(defmessage |ParameterAref|
+(defmessage |ParameterAref| ()
     (
      (|name|
       :documentation "The parameter name"
@@ -48,7 +48,7 @@
      )
   :documentation "A parametric expression.")
 
-(defmessage |PatchTarget|
+(defmessage |PatchTarget| ()
     (
      (|patch_type|
       :documentation "Data type at this address."
@@ -63,7 +63,7 @@
 
   :documentation "Patchable memory location descriptor.")
 
-(defmessage |RPCRequest|
+(defmessage |RPCRequest| ()
     (
      (|jsonrpc|
       :documentation "The JSONRPC version."
@@ -88,7 +88,7 @@
      )
   :documentation "A single request object according to the JSONRPC standard.")
 
-(defmessage |RPCReply|
+(defmessage |RPCReply| ()
     (
      (|jsonrpc|
       :documentation "The JSONRPC version."
@@ -108,7 +108,7 @@
      )
   :documentation "The reply for a JSONRPC request.")
 
-(defmessage |RPCError|
+(defmessage |RPCError| ()
     (
      (|jsonrpc|
       :documentation "The JSONRPC version."
@@ -128,7 +128,7 @@
      )
   :documentation "A error message for JSONRPC requests.")
 
-(defmessage |TargetDevice|
+(defmessage |TargetDevice| ()
     ((|isa|
       :documentation "Instruction-set architecture for this device."
       :type (:map :string -> :map)
@@ -140,7 +140,7 @@
       :required t))
   :documentation "ISA and specs for a particular device.")
 
-(defmessage |RandomizedBenchmarkingRequest|
+(defmessage |RandomizedBenchmarkingRequest| ()
     ((|depth|
       :documentation "Depth of the benchmarking sequence."
       :type :integer
@@ -168,7 +168,7 @@
 
   :documentation "RPC request payload for generating a randomized benchmarking sequence.")
 
-(defmessage |RandomizedBenchmarkingResponse|
+(defmessage |RandomizedBenchmarkingResponse| ()
     ((|sequence|
       :documentation "List of Cliffords, each expressed as a list of generator indices."
       :type (:list (:list :integer))
@@ -176,7 +176,7 @@
 
   :documentation "RPC reply payload for a randomly generated benchmarking sequence.")
 
-(defmessage |PauliTerm|
+(defmessage |PauliTerm| ()
     ((|indices|
       :documentation "Qubit indices onto which the factors of a Pauli term are applied."
       :type (:list :integer)
@@ -189,7 +189,7 @@
 
   :documentation "Specification of a single Pauli term as a tensor product of Pauli factors.")
 
-(defmessage |ConjugateByCliffordRequest|
+(defmessage |ConjugateByCliffordRequest| ()
     ((|pauli|
       :documentation "Specification of a Pauli element."
       :type |PauliTerm|
@@ -202,7 +202,7 @@
 
   :documentation "RPC request payload for conjugating a Pauli element by a Clifford element.")
 
-(defmessage |ConjugateByCliffordResponse|
+(defmessage |ConjugateByCliffordResponse| ()
     ((|phase|
       :documentation "Encoded global phase factor on the emitted Pauli."
       :type :integer
@@ -215,7 +215,7 @@
 
   :documentation "RPC reply payload for a Pauli element as conjugated by a Clifford element.")
 
-(defmessage |NativeQuilRequest|
+(defmessage |NativeQuilRequest| ()
     ((|quil|
       :documentation "Arbitrary Quil to be sent to quilc."
       :type :string
@@ -227,7 +227,7 @@
       :required t))
   :documentation "Quil and the device metadata necessary for quilc.")
 
-(defmessage |NativeQuilMetadata|
+(defmessage |NativeQuilMetadata| ()
     ((|final_rewiring|
       :documentation "Output qubit index relabeling due to SWAP insertion."
       :type (:list :integer)
@@ -264,7 +264,7 @@
       :required nil))
   :documentation "Metadata for a native quil program.")
 
-(defmessage |NativeQuilResponse|
+(defmessage |NativeQuilResponse| ()
     ((|quil|
       :documentation "Native Quil returned from quilc."
       :type :string
@@ -276,14 +276,14 @@
       :required nil))
   :documentation "Native Quil and associated metadata returned from quilc.")
 
-(defmessage |RewriteArithmeticRequest|
+(defmessage |RewriteArithmeticRequest| ()
     ((|quil|
       :documentation "Native Quil for which to rewrite arithmetic parameters."
       :type :string
       :required t))
   :documentation "A request type to handle compiling arithmetic out of gate parameters.")
 
-(defmessage |RewriteArithmeticResponse|
+(defmessage |RewriteArithmeticResponse| ()
     ((|quil|
       :documentation "Native Quil rewritten with no arithmetic in gate parameters."
       :type :string
@@ -300,7 +300,7 @@
       :required nil))
   :documentation "The data needed to run programs with gate arithmetic on the hardware.")
 
-(defmessage |BinaryExecutableRequest|
+(defmessage |BinaryExecutableRequest| ()
     ((|quil|
       :documentation "Native Quil to be translated into an executable program."
       :type :string
@@ -312,7 +312,7 @@
       :required t))
   :documentation "Native Quil and the information needed to create binary executables.")
 
-(defmessage |BinaryExecutableResponse|
+(defmessage |BinaryExecutableResponse| ()
     ((|program|
       :documentation "Execution settings and sequencer binaries."
       :type :string
@@ -331,7 +331,7 @@
       :default nil))
   :documentation "Program to run on the QPU.")
 
-(defmessage |PyQuilExecutableResponse|
+(defmessage |PyQuilExecutableResponse| ()
     ((|program|
       :documentation "String representation of a Quil program."
       :type :string
@@ -343,7 +343,7 @@
       :required t))
   :documentation "rpcQ-serializable form of a pyQuil Program object.")
 
-(defmessage |QPURequest|
+(defmessage |QPURequest| ()
     ((|program|
       :documentation "Execution settings and sequencer binaries."
       :type :any

--- a/src/rpcq-python.lisp
+++ b/src/rpcq-python.lisp
@@ -1,0 +1,294 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Copyright 2018 Rigetti Computing
+;;;;
+;;;;    Licensed under the Apache License, Version 2.0 (the "License");
+;;;;    you may not use this file except in compliance with the License.
+;;;;    You may obtain a copy of the License at
+;;;;
+;;;;        http://www.apache.org/licenses/LICENSE-2.0
+;;;;
+;;;;    Unless required by applicable law or agreed to in writing, software
+;;;;    distributed under the License is distributed on an "AS IS" BASIS,
+;;;;    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;;;    See the License for the specific language governing permissions and
+;;;;    limitations under the License.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;
+;;;; rpcq-python.lisp
+;;;;
+;;;; Authors: Nikolas Tezak, Eric Peterson
+;;;;
+
+(in-package #:rpcq)
+
+
+(defparameter *python-types*
+  '(:string "str"
+    :bytes "bytes"
+    :float "float"
+    :integer "int"
+    :bool "bool"
+    :map "Dict"
+    :list "List"
+    :any "Any"))
+
+(defparameter *python-instance-check-types*
+  '(:string "basestring"
+    :bytes "bytes"
+    :float "float"
+    :integer "int"
+    :bool "bool"
+    :map "dict"
+    :list "list"
+    :any "object"))
+
+
+(defun python-instance-check-type (field-type)
+  (let ((*python-types* *python-instance-check-types*))
+    (python-type field-type)))
+
+(defun python-argspec-default (field-type default)
+  "Translate DEFAULT values for immutable objects of a given
+FIELD-TYPE to python."
+  (typecase field-type
+    ((eql :string)
+     (if default
+         (format nil "~S" default)
+         "None"))
+    ((eql :bytes)
+     (if default
+         (format nil "b~S" (to-string default))
+         "None"))
+    ((eql :bool)
+     (if default
+         "True"
+         "False"))
+    ((eql :integer)
+     (if default
+         (format nil "~d" default)
+         "None"))
+    ((eql :float)
+     (if default
+         (format nil "~e" default)
+         "None"))
+    ((cons (eql :list))
+     (if default
+         (format nil "[~{~S~^, ~}]" default)
+         "field(default_factory=list)"))
+    ((cons (eql :map))
+     (when default
+       (warn "I don't know how to encode default dictionaries into generated python3 output."))
+     "field(default_factory=dict)")
+    (otherwise
+     "None")))
+
+(defun python-type (field-type)
+  "Always return a basic python type not List[...] or Dict[...] for
+instance checks."
+  (python-typing-type
+   (if (listp field-type)
+       (car field-type)
+       field-type)))
+
+(defun python-typing-type (field-type)
+  "Return the python typing-module compliant field type"
+  (etypecase field-type
+    (keyword
+     (assert (member field-type *python-types*)
+             (field-type)
+             "Unknown field-type ~S" field-type)
+     (getf *python-types* field-type))
+    (symbol
+     ;; field-type is assumed to be message object
+     (format nil "~a" field-type))
+    ((cons (eql :list))
+     (format nil "List[~a]" (python-typing-type (cadr field-type))))
+    ((cons (eql :map))
+     (assert (string= (symbol-name (caddr field-type)) "->")
+             (field-type)
+             "Bad mapping spec.")
+     (format nil
+             "Dict[~a, ~a]"
+             (python-typing-type (cadr field-type))
+             (python-typing-type (cadddr field-type))))))
+
+(defun python-maybe-optional-typing-type (field-type required)
+  "Rerturn the python type string for FIELD-TYPE while
+accounting for whether the field is REQUIRED.
+"
+  (let ((b (python-typing-type field-type)))
+    (if (or required (listp field-type))
+        b
+        (format nil "Optional[~a]" b))))
+
+(defun python-collections-initform (field-type default)
+  "Translate a DEFAULT value of type FIELD-TYPE to a python initform."
+  (check-type field-type list)
+  (etypecase field-type
+    ;; handle lists
+    ((cons (eql :list))
+     (if (null default)
+         "[]"
+         (with-output-to-string (s)
+           (yason:encode default s))))
+
+    ;; handle mappings
+    ((cons (eql :map))
+     (if (null default)
+         "{}"
+         (with-output-to-string (s)
+           (yason:encode (%plist-to-string-hash-table default) s))))))
+
+
+(defun python-message-spec (stream &optional parent-modules)
+  "Print an importable python file with the message definitions."
+  (flet ((python-out (line-list)
+           (dolist (line line-list)
+             (apply 'format stream line)
+             (terpri stream))
+           (terpri stream)))
+    (format stream "~
+#!/usr/bin/env python
+
+\"\"\"
+WARNING: This file is auto-generated, do not edit by hand. See README.md.
+\"\"\"
+
+from warnings import warn
+from rpcq._base import Message
+from dataclasses import dataclass, field, InitVar
+from typing import Any, List, Dict, Optional, Union, Tuple~%~%")
+    (format stream "~{from ~a import *~%~}~%" parent-modules)
+    
+    (dolist (message-spec *messages*)
+      (destructuring-bind (msg-name parent-name field-specs documentation) message-spec
+        
+        ;; print the class header
+        (python-out `(("@dataclass(eq=False, repr=False)")
+                      ("class ~a(~a):"                     ,(symbol-name msg-name)
+                                                           ,(if parent-name
+                                                                (symbol-name parent-name)
+                                                                "Message"))
+                      ("    \"\"\"")
+                      ("    ~a"                            ,documentation)
+                      ("    \"\"\"")))
+        
+        (let ((deprecated-fields nil))
+          
+          ;; python dataclasses require their fields to be written in the order
+          ;; * required slots
+          ;; * optional slots
+          ;; * deprecated slots
+          
+          (labels ((requiredp (r)
+                     (and (not (member ':default (rest r)))
+                          (getf (rest r) ':required)))
+                   (optionalp (r)
+                     (not (requiredp r)))
+                   (deprecatedp (r)
+                     (or (getf (cdr r) ':deprecated)
+                         (getf (cdr r) ':deprecated-by))))
+            (setf field-specs (sort (copy-seq field-specs)
+                                    (lambda (r s)
+                                      (or (and (requiredp r) (optionalp s))
+                                          (and (requiredp r) (deprecatedp s))
+                                          (and (optionalp r) (deprecatedp s)))))))
+          
+          (dolist (field-spec field-specs)
+            (let* ((slot-name (car field-spec))
+                   (field-settings (cdr field-spec))
+                   (type (getf field-settings ':type))
+                   (required (getf field-settings ':required))
+                   (documentation (getf field-settings ':documentation))
+                   (defaultp (member ':default field-settings))
+                   (default (or (getf field-settings ':default)))
+                   (deprecated (getf field-settings ':deprecated))
+                   (deprecates (getf field-settings ':deprecates))
+                   (deprecated-by (getf field-settings ':deprecated-by)))
+              
+              ;; optional fields automatically acquire a NIL default
+              (unless (or required defaultp)
+                (setf default nil)
+                (setf defaultp t))
+              
+              ;; print the slot descriptor
+              (cond
+                ;; recipe for a deprecated slot
+                ((or deprecated-by deprecated)
+                 (python-out `(("    ~a: InitVar[~a] = None" ,(symbol-name slot-name)
+                                                             ,(python-maybe-optional-typing-type type required))
+                               ("    \"\"\"~a\"\"\""         ,documentation)))
+                 (when deprecated
+                   (push (list slot-name nil required) deprecated-fields)))
+                ;; recipe for a deprecating slot
+                (deprecates
+                 (let ((definite-default (or (python-argspec-default type default) "None")))
+                   (python-out `(("    ~a: ~a = ~a"      ,(symbol-name slot-name)
+                                                         ,(python-maybe-optional-typing-type type t)
+                                                         ,definite-default)
+                                 ("    \"\"\"~a\"\"\""   ,documentation))))
+                 (push (list deprecates slot-name required) deprecated-fields))
+                ;; recipe for a slot with a default value
+                (defaultp
+                 (python-out `(("    ~a: ~a = ~a"       ,(symbol-name slot-name)
+                                                        ,(python-maybe-optional-typing-type type required)
+                                                        ,(python-argspec-default type default))
+                               ("    \"\"\"~a\"\"\""    ,documentation))))
+                ;; recipe for a slot otherwise
+                (t
+                 (python-out `(("    ~a: ~a"           ,(symbol-name slot-name)
+                                                       ,(python-maybe-optional-typing-type type required))
+                               ("    \"\"\"~a\"\"\""   ,documentation)))))))
+          
+          ;; deprecated fields need special care.
+          (when deprecated-fields
+            ;; (1) add fake getters / setters
+            (dolist (field-spec deprecated-fields)
+              (destructuring-bind (old new new-required) field-spec
+                (declare (ignore new-required))
+                (when new
+                  (python-out `(("    @property")
+                                ("    def ~a(self):"                                ,(symbol-name old))
+                                ("        warn('~a is deprecated, use ~a instead')" ,(symbol-name old)
+                                                                                    ,(symbol-name new))
+                                ("        return self.~a"                           ,(symbol-name new))
+                                ("")
+                                ("    @~a.setter"                                   ,(symbol-name old))
+                                ("    def ~a(self, value):"                         ,(symbol-name old))
+                                ("        warn('~a is deprecated, use ~a instead')" ,(symbol-name old)
+                                                                                    ,(symbol-name new))
+                                ("        self.~a = value"                          ,(symbol-name new)))))))
+            
+            ;; (2) add extra fields to output
+            (python-out `(("    def _extend_by_deprecated_fields(self, d):")
+                          ("        super()._extend_by_deprecated_fields(d)")))
+            (dolist (field-spec deprecated-fields)
+              (destructuring-bind (old new new-required) field-spec
+                (declare (ignore new-required))
+                (when new
+                  (python-out `(("        d.~a = d.~a" ,(symbol-name old)
+                                                       ,(symbol-name new)))))))
+            
+            ;; (3) tolerate extra fields on input
+            (format stream
+                    "    def __post_init__(self, ~{~a~^, ~}):~%"
+                    (mapcar (alexandria:compose #'symbol-name #'first) deprecated-fields))
+            (dolist (field-spec deprecated-fields)
+              (destructuring-bind (old new new-required) field-spec
+                (cond
+                  (new
+                   (python-out `(("        if not isinstance(~a, property):"                       ,(symbol-name old))
+                                 ("            if \"~a\" not in self.__dict__ or self.~a is None:" ,(symbol-name new)
+                                                                                                   ,(symbol-name new))
+                                 ("                warn('~a is deprecated, use ~a instead')"       ,(symbol-name old)
+                                                                                                   ,(symbol-name new))
+                                 ("                self.__dict__[\"~a\"] = ~a~%"                   ,(symbol-name new)
+                                                                                                   ,(symbol-name old))))
+                   (when new-required
+                     (python-out `(("        if \"~a\" not in self.__dict__ or self.~a is None:" ,(symbol-name new)
+                                                                                                 ,(symbol-name new))
+                                   ("            raise(TypeError(\"~a is a required key.\"))~%"  ,(symbol-name new))))))
+                  (t
+                   (python-out `(("        if not isinstance(~a, property):"                            ,(symbol-name old))
+                                 ("            warn('~a is deprecated; please don\\'t set it anymore')" ,(symbol-name old))))))))))
+        (python-out '())))))

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -1,4 +1,3 @@
-;;;; rpcq.lisp
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Copyright 2018 Rigetti Computing
 ;;;;
@@ -14,6 +13,9 @@
 ;;;;    See the License for the specific language governing permissions and
 ;;;;    limitations under the License.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;
+;;;; rpcq.lisp
+;;;;
 
 (in-package #:rpcq)
 
@@ -33,36 +35,12 @@
   '(member :string :bytes :bool :float :integer :any))
 
 
-(defparameter *python-types*
-  '(:string "str"
-    :bytes "bytes"
-    :float "float"
-    :integer "int"
-    :bool "bool"
-    :map "dict"
-    :list "list"
-    :any "object"))
-
-(defparameter *python-instance-check-types*
-  '(:string "basestring"
-    :bytes "bytes"
-    :float "float"
-    :integer "int"
-    :bool "bool"
-    :map "dict"
-    :list "list"
-    :any "object"))
-
 (defun format-documentation-string (string)
   "Format a documentation string STRING into its final stored representation.
 
 The input strings are assumed to be FORMAT-compatible, so sequences like ~<newline> are allowed."
   (check-type string string)
   (format nil string))
-
-(defun python-instance-check-type (field-type)
-  (let ((*python-types* *python-instance-check-types*))
-    (python-type field-type)))
 
 (defun to-octets (string)
   "Convert a string S to a vector of 8-bit unsigned bytes"
@@ -72,307 +50,6 @@ The input strings are assumed to be FORMAT-compatible, so sequences like ~<newli
   "Convert a vector of octets to a string"
   (map 'string 'code-char octets))
 
-(defun python-argspec-default (field-type default)
-  "Translate DEFAULT values for immutable objects of a given
-FIELD-TYPE to python."
-  (case field-type
-    ((:string)
-     (if default
-         (format nil "~S" default)
-         "None"))
-    ((:bytes)
-     (if default
-         (format nil "b~S" (to-string default))
-         "None"))
-    ((:bool)
-     (if default
-         "True"
-         "False"))
-    ((:integer)
-     (if default
-         (format nil "~d" default)
-         "None"))
-    ((:float)
-     (if default
-         (format nil "~e" default)
-         "None"))
-    (otherwise
-     "None")))
-
-(defun python-type (field-type)
-  "Always return a basic python type not List[...] or Dict[...] for
-instance checks."
-  (python-typing-type
-   (if (listp field-type)
-       (car field-type)
-       field-type)))
-
-(defun python-typing-type (field-type)
-  "Return the python typing-module compliant field type"
-  (cond
-    ((keywordp field-type)
-     (assert (member field-type *python-types*)
-             (field-type)
-             "Unknown field-type ~S" field-type)
-     (getf *python-types* field-type))
-    ((symbolp field-type)
-     ;; field-type is assumed to be message object
-     (format nil "~a" field-type))
-    ((eq (car field-type) :list)
-     (format nil "List[~a]" (python-typing-type (cadr field-type))))
-    ((eq (car field-type) :map)
-     (assert (string= (symbol-name (caddr field-type)) "->")
-             (field-type)
-             "Bad mapping spec.")
-     (format nil
-             "Dict[~a,~b]"
-             (python-typing-type (cadr field-type))
-             (python-typing-type (cadddr field-type))))))
-
-(defun python-maybe-optional-typing-type (field-type required)
-  "Rerturn the python type string for FIELD-TYPE while
-accounting for whether the field is REQUIRED.
-"
-  (let ((b (python-typing-type field-type)))
-    (if (or required
-            (listp field-type))
-        b
-        (format nil "Optional[~a]" b))))
-
-(defun python-collections-initform (field-type default)
-  "Translate a DEFAULT value of type FIELD-TYPE to a python initform."
-  (check-type field-type list)
-  (cond
-    ;; handle lists
-    ((eq :list (car field-type))
-     (if (null default)
-         "[]"
-         (with-output-to-string (s)
-           (yason:encode default s))))
-
-    ;; handle mappings
-    ((eq :map (car field-type))
-     (if (null default)
-         "{}"
-         (with-output-to-string (s)
-           (yason:encode (%plist-to-string-hash-table default) s))))
-    (t
-     (error "Unrecognized field-type ~A" field-type))))
-
-
-(defun python-message-spec (&optional (stream nil))
-  "print an importable python file with the message definitions"
-  (format stream "#!/usr/bin/env python
-
-\"\"\"
-WARNING: This file is auto-generated, do not edit by hand. See README.md.
-\"\"\"
-
-import warnings
-from rpcq._base import Message
-from typing import List, Dict, Optional
-
-# Python 2/3 str/unicode compatibility
-from past.builtins import basestring
-
-
-class CoreMessages(object):
-    \"\"\"
-    WARNING: This class is auto-generated, do not edit by hand. See README.md.
-    This class is also DEPRECATED.
-    \"\"\"
-
-
-class _deprecated_property(object):
-
-    def __init__(self, prop):
-        self.prop = prop
-
-    def __get__(self, *args):
-        warnings.warn(
-            \"'CoreMessages.{0}' is deprecated. Please access '{0}' directly at the module level.\".format(
-                self.prop.__name__),
-            UserWarning)
-        return self.prop
-
-")
-  ;; for each message we need:
-  ;; - the message name and documentation
-  ;; - the message field names to define the
-  ;;   slots as well as the asdict and astuple methods
-  ;; - the constructor definition argument specification
-  ;;   (includes default values for primitive types)
-  ;; - the constructor type signature
-  ;; - the default values for lists and dicts
-  ;; - the not-None checks for all required arguments
-  ;; - the type checks for all arguments (accounting for required args)
-  ;; - the instance attribute assignment plus attribute docstring
-  (loop :for (msg-name field-specs documentation) :in *messages*
-        :collect
-        (let
-            (slot-names
-             args-no-default
-             args-with-default
-             required-args
-             field-instantiations
-             type-checks
-             collections-defaults)
-          (loop :for (name . params) :in (reverse field-specs)
-                :for required := (getf params :required)
-                :for type := (getf params :type)
-                :for typing-type := (python-maybe-optional-typing-type type required)
-                :for basic-type := (python-type type)
-                :for instance-check-type := (python-instance-check-type type)
-                :for defaultp := (member :default params)
-                :for default := (getf params :default)
-                :for collectionp := (listp type)
-                :for documentation := (getf params :documentation
-                                            (format nil "Field ~a of type ~a" name type))
-                :do
-                   ;; slot names
-                   (push name slot-names)
-
-                   ;; constructor arguments
-                   (if (and required
-                            (not defaultp))
-
-                       ;; regular positional argument
-                       (push (list name typing-type) args-no-default)
-
-                       ;; keyword argument
-                       (push (list
-                              (format nil "~a=~a" name
-                                      (python-argspec-default
-                                       type
-                                       default))
-                              typing-type)
-                             args-with-default))
-
-                   ;; required arguments that are not collections with
-                   ;; default values
-                   (when (and required
-                              (or
-                               (not defaultp)
-                               (not collectionp)))
-                     (push name required-args))
-
-                   ;; instance attribute initializations
-                   (push (list name typing-type documentation) field-instantiations)
-
-                   ;; type checking
-                   (push
-                    (list required name instance-check-type name instance-check-type name)
-                    type-checks)
-
-                   ;; Initialize default values for collections
-                   (when (and collectionp
-                              (or (not required)
-                                  defaultp))
-                     (push (list
-                            name
-                            (python-collections-initform type default))
-                           collections-defaults)))
-          (let
-              ;; concatenate positional and keyword args
-              ((init-arg-spec
-                 (concatenate 'list
-                              (mapcar #'car args-no-default)
-                              (mapcar #'car args-with-default)))
-
-               ;; constructor argument type signature
-               (typing-types-arg-spec
-                 (concatenate 'list
-                              (mapcar #'cadr args-no-default)
-                              (mapcar #'cadr args-with-default))))
-
-            ;; Add class header, documentation and implementations of
-            ;; asdict and astuple
-            (format stream
-                    "~&
-class ~A(Message):
-    \"\"\"~a\"\"\"
-
-    # fix slots
-    __slots__ = (
-        ~{'~a'~^,
-        ~},
-    )
-
-    def asdict(self):
-        \"\"\"Generate dictionary representation of self.\"\"\"
-        return {
-            ~:*~{'~a~:*': self.~a~^,
-            ~}
-        }
-
-    def astuple(self):
-        \"\"\"Generate tuple representation of self.\"\"\"
-        return (
-            ~:*~{self.~a~^,
-            ~}
-        )~%"
-                    (symbol-name msg-name)
-                    (or documentation (symbol-name msg-name))
-                    slot-names)
-
-            ;; Add constructor signature and type hint
-            (format stream  "
-    def __init__(self,
-                 ~{~a~^,
-                 ~},
-                 **kwargs):
-        # type: (~{~a~^, ~}) -> None~%
-        if kwargs:
-            warnings.warn((\"Message {} ignoring unexpected keyword arguments: \"
-                    \"{}.\").format(self.__class__.__name__, \", \".join(kwargs.keys())))
-"
-                    init-arg-spec
-                    typing-types-arg-spec)
-
-            ;; Initialize collections (list+dict) that either have
-            ;; default values or are optional to empty containers if
-            ;; they are None
-            (when collections-defaults
-              (format stream "
-        ~:[~;# initialize default values of collections~]~:*
-        ~{if ~a is None:
-            ~:*~a = ~a~^
-        ~}~%"
-                      (apply #'append collections-defaults)))
-
-            ;; Check that required fields are not None (skip
-            ;; collections with default values as those are
-            ;; automatically converted to empty containers above
-            (when required-args
-              (format stream "
-        ~:[~;# check presence of required fields~]~:*
-        ~{if ~a~:* is None:
-            raise ValueError(\"The field '~a' cannot be None\")~^
-        ~}~%"
-                      required-args))
-
-            ;; Verify field types. For non-required fields a value of
-            ;; None is permitted
-            (when type-checks
-              (format stream "
-        ~:[~;# verify types~]~:*
-        ~{if not ~:[(~a is None or isinstance(~:*~a, ~a))~;isinstance(~a, ~a)~]:
-            raise TypeError(\"Parameter ~a must be of type ~a, \"
-                            + \"but object of type {} given\".format(type(~a)))~^
-        ~}~%"
-                      (apply #'append type-checks)))
-
-            ;; Actually set the instance attributes and add type hint
-            ;; and docstring
-            (format stream "
-        ~{self.~a~:* = ~a  # type: ~a
-        \"\"\"~a\"\"\"~^
-
-        ~}~%"
-                    (apply #'append field-instantiations))
-            (format stream "
-CoreMessages.~A = _deprecated_property(~:*~A)
-" (symbol-name msg-name))))))
 
 (defun serialize (obj &optional stream)
   "Serialize OBJ, either written to a stream or returned as a vector of (INTEGER 0 255)."
@@ -533,78 +210,197 @@ We distinguish between the following options for any field type:
     tbl))
 
 
-(defmacro defmessage (class-name field-specs &key (documentation nil))
-  "Create a (de-)serializable message definition with name CLASS-NAME and slots (SLOT-SPECS)."
+(defmacro defmessage (class-name parent-name field-specs &key (documentation nil))
+  "Create a (de-)serializable message definition.
+
+PARAMETERS:
+  * CLASS-NAME: The name of the message type.
+  * PARENT-NAME: A list of length at most 1 of \"parent message types\". Child message types inherit their parents slot specifications.
+  * FIELD-SPECS: A list of slot specifications for the message type.  An entry in FIELD-SPECS is a plist with the following possible keys:
+    :TYPE          - Either an atomic type, a list type, a map type, or another RPCQ message name.
+    :REQUIRED      - A boolean indicating whether the field is required. If it is required, there must be a default value, either supplied through :DEFAULT or implicitly.
+    :DOCUMENTATION - A documentation string.
+    :DEFAULT       - A default value for the slot.
+    :DEPRECATES    - The slot name that this slot replaces.
+    :DEPRECATED-BY - The slot name that this slot is replaced by.
+    :DEPRECATED    - Indicates that this slot is being phased out without a replacement.
+
+LIMITATIONS:
+  * DEPRECATES / DEPRECATED-BY must come in balanced pairs.
+  * DEPRECATES / DEPRECATED-BY are mutually exclusive. (Nested deprecation is not currently supported.)
+  * DEPRECATES / DEPRECATED-BY must reference slots on the same message, and not on parent messages."
   (check-type class-name symbol)
-  (setf *messages* (nconc *messages* `((,class-name ,field-specs ,documentation))))
-  (flet ((accessor (slot-name)
-           (alexandria:symbolicate (symbol-name class-name)
-                                   "-"
-                                   (symbol-name slot-name))))
-    (flet ((make-slot-spec (field-spec)
+  (assert (or (null parent-name)
+              (and (typep parent-name 'cons)
+                   (= 1 (length parent-name)))))
+  (setf *messages* (nconc *messages* `((,class-name ,(first parent-name) ,field-specs ,documentation))))
+  (labels ((accessor (slot-name)
+             (alexandria:symbolicate (symbol-name class-name)
+                                     "-"
+                                     (symbol-name slot-name)))
+           (make-slot-spec (field-spec)
              (let*
                  ((slot-name (car field-spec))
                   (field-settings (cdr field-spec))
-                  (field-type (getf field-settings :type))
-                  (required (getf field-settings :required))
-                  (documentation (getf field-settings :documentation))
-                  (defaultp (member :default field-settings))
-                  (default (getf field-settings :default)))
-
+                  (field-type (getf field-settings ':type))
+                  (required (getf field-settings ':required))
+                  (documentation (getf field-settings ':documentation))
+                  (defaultp (member ':default field-settings))
+                  (default (getf field-settings ':default))
+                  (deprecated (getf field-settings ':deprecated))
+                  (deprecates (getf field-settings ':deprecates))
+                  (deprecated-by (getf field-settings ':deprecated-by)))
+               
+               (assert (not (and deprecates deprecated-by))
+                       ()
+                       "It is currently unsupported for messages to have multiple levels of deprecation.")
+               
+               (assert (not (and deprecated (or deprecates deprecated-by)))
+                       ()
+                       "It does not make sense to deprecate a field simultaneously with and without replacement.")
+               
                (multiple-value-bind (slot-type initform)
                    (slot-type-and-initform field-type required default)
-                 `(,slot-name :initarg ,(intern (symbol-name slot-name) :keyword)
-                              :reader ,(accessor slot-name)
-                              :type ,slot-type
+                 `(,slot-name
+                   ;; a slot can have multiple initialization vectors.
+                   ;; we allow a slot to be initialized by its own name, by the
+                   ;; name of a slot that it deprecates, and by the name of a slot
+                   ;; that it's deprecated by. these override each other: we
+                   ;; prefer the slot that it's deprecated by to our own name,
+                   ;; which we in turn prefer to the slot which we deprecate.
+                   ,@(when deprecates
+                       `(:initarg ,(intern (symbol-name deprecates) :keyword)))
+                   :initarg ,(intern (symbol-name slot-name) :keyword)
+                   ,@(when deprecated-by
+                       `(:initarg ,(intern (symbol-name deprecated-by) :keyword)))
+                   
+                   :reader ,(accessor slot-name)
+                   :type ,slot-type
 
-                              ;; only add documentation if present
-                              ,@(when documentation
-                                  (list :documentation (format-documentation-string
-                                                        documentation)))
+                   ;; only add documentation if present
+                   ,@(when documentation
+                       (list :documentation (format-documentation-string
+                                             documentation)))
 
-                              ;; if no default value given
-                              ;; but field is required raise error
-                              ,@(if (and required (not defaultp))
-                                    `(:initform (error
-                                                 (concatenate
-                                                  'string
-                                                  "Missing value for field "
-                                                  ,(symbol-name slot-name))))
-                                    ;; else initialize to
-                                    ;; initform generated by TRANSLATE-FIELD-TYPE
-                                    `(:initform ,initform))))))
+                   ;; if no default value given
+                   ;; but field is required raise error
+                   ,@(if (and required (not defaultp))
+                         `(:initform (error
+                                      (concatenate
+                                       'string
+                                       "Missing value for field "
+                                       ,(symbol-name slot-name))))
+                         ;; else initialize to
+                         ;; initform generated by TRANSLATE-FIELD-TYPE
+                         `(:initform ,initform))))))
+           (slot-initialization-deprecation-warnings (field-spec)
+             (let* ((slot-name (car field-spec))
+                    (slot-keyword (intern (symbol-name slot-name) :keyword))
+                    (field-settings (cdr field-spec)))
+               (alexandria:when-let* ((deprecated-by (getf field-settings ':deprecated-by))
+                                      (deprecated-by-keyword (intern (symbol-name deprecated-by) :keyword)))
+                 (list `(when (and (getf initargs ,slot-keyword)
+                                   (not (getf initargs ,deprecated-by-keyword)))
+                          (warn ,(format nil "~a has been deprecated by ~a."
+                                         slot-keyword deprecated-by-keyword)))))))
+           (slot-accessor-deprecation-warnings (field-spec)
+             (let* ((slot-name (car field-spec))
+                    (slot-keyword (intern (symbol-name slot-name) :keyword))
+                    (field-settings (cdr field-spec)))
+               (alexandria:when-let* ((deprecated-by (getf field-settings ':deprecated-by))
+                                      (deprecated-by-keyword (intern (symbol-name deprecated-by) :keyword)))
+                 (list `(defmethod ,(accessor slot-name) ((obj ,class-name))
+                          (warn ,(format nil "~a has been deprecated by ~a."
+                                         slot-keyword deprecated-by-keyword))
+                          (,(accessor deprecated-by) obj))))))
            (init-spec (json)
              (lambda (slot-name)
                `( ,(intern (symbol-name slot-name) :keyword)
                   (%deserialize (gethash ,(symbol-name slot-name) ,json))))))
-      (alexandria:with-gensyms (obj hash-table)
-        (let ((slot-names (mapcar #'car field-specs)))
-          `(progn
-             (defclass ,class-name ()
-               ,(mapcar #'make-slot-spec field-specs)
-               ,@(when documentation
-                   `((:documentation ,(format-documentation-string documentation)))))
-             
-             (defmethod %serialize ((,obj ,class-name))
-               (with-slots ,slot-names ,obj
-                 (let ((,hash-table (make-hash-table :test #'equal)))
-                   (setf (gethash "_type" ,hash-table) ,(symbol-name class-name))
-                   ,@(loop :for slot :in slot-names
-                           :collect `(setf (gethash ,(symbol-name slot) ,hash-table)
-                                           (%serialize ,slot)))
-                   ,hash-table)))
+    (alexandria:with-gensyms (obj init-args)
+      (let ((slot-names (mapcar #'car field-specs)))
+        `(progn
+           ;; here we define the actual message class object.
+           ;; the most complicated aspect is setting up all the slot definitions
+           ;; (which store default init values, type info, ...).
+           (defclass ,class-name ,parent-name
+             ,(mapcar #'make-slot-spec field-specs)
+             ,@(when documentation
+                 `((:documentation ,(format-documentation-string documentation)))))
+           
+           ;; in the event that our message has deprecated slots, we need to
+           ;; warn the user if they use them during initialization.
+           (defmethod shared-initialize ((instance ,class-name) slot-names
+                                         &rest initargs
+                                         &key &allow-other-keys)
+             ,@(mapcan #'slot-initialization-deprecation-warnings field-specs)
+             (call-next-method))
+           
+           ;; similarly, we warn a user who tries to read from deprecated slots
+           ,@(mapcan #'slot-accessor-deprecation-warnings field-specs)
+           
+           ;; in order to serialize our message, we recurse through our class
+           ;; ancestry and load up a hash table with all our slots. this splits
+           ;; into two parts: initializing the hash table (done here) and the
+           ;; recursion (done in %%serialize)
+           (defmethod %serialize ((,obj ,class-name))
+             (%%serialize ,obj (make-hash-table :test #'equal)))
+           
+           (defmethod %%serialize ((,obj ,class-name) (hash-table hash-table))
+             (with-slots ,slot-names ,obj
+               ,@(loop :for slot :in slot-names
+                       :collect `(setf (gethash ,(symbol-name slot) hash-table)
+                                       (%serialize ,slot)))
+               (call-next-method)
+               (setf (gethash "_type" hash-table) ,(symbol-name class-name))
+               hash-table))
 
-             (defmethod %deserialize-struct ((type (eql ',class-name)) (payload hash-table))
-               (assert (string= (gethash "_type" payload) ,(symbol-name class-name)))
-               (make-instance ',class-name
-                              ,@(mapcan (init-spec 'payload) slot-names)))
+           ;; similarly, in order to deserialize a message we recurse over our
+           ;; class ancestry and load up a hash table with all of the expected
+           ;; slots. this also cleaves into two parts: setting up the hash
+           ;; table (done here) and the recursion (done in %%deserialize-struct)
+           (defmethod %deserialize-struct ((type (eql ',class-name)) (payload hash-table))
+             (assert (string= (gethash "_type" payload) ',class-name))
+             (let ((,init-args (%%deserialize-struct type payload)))
+               (apply 'make-instance
+                      ',class-name
+                      ,init-args)))
+           
+           (defmethod %%deserialize-struct ((type (eql ',class-name)) (payload hash-table))
+             ,(cond
+                (parent-name
+                 `(list*
+                   ,@(mapcan (init-spec 'payload) slot-names)
+                   (%%deserialize-struct ',@parent-name payload)))
+                (t
+                 `(list ,@(mapcan (init-spec 'payload) slot-names)))))
 
+           ;; similarly similarly, in order to print out the contents of an RPCQ
+           ;; message we walk over our class ancestry and print out all the
+           ;; slots that each ancestor contributes.  this also also cleaves into
+           ;; two parts: setting up the basics of the printing (done here) and
+           ;; the recursion (done in %print-slots)
+           (defmethod print-object ((,obj ,class-name) stream)
+             (print-unreadable-object (,obj stream :type t)
+               (pprint-indent :block 2)
+               (%print-slots ,obj stream)))
+           
+           (defmethod %print-slots ((,obj ,class-name) stream)
+             ,@(loop :for spec :in field-specs
+                     :unless (getf (cdr spec) ':deprecated-by)
+                       :collect `(format stream
+                                         "~&  ~A -> ~S"
+                                         ,(symbol-name (car spec))
+                                         (,(accessor (car spec)) ,obj)))
+             (call-next-method))
+           
+           nil)))))
 
-             (defmethod print-object ((,obj ,class-name) stream)
-               (print-unreadable-object (,obj stream :type t)
-                 (pprint-indent :block 2)
-                 ,@(loop :for slot :in slot-names
-                         :collect `(format stream
-                                           "~&  ~A -> ~S"
-                                           ,(symbol-name slot)
-                                           (,(accessor slot) ,obj)))))))))))
+(defmethod %print-slots (obj stream)
+  nil)
+
+(defmethod %%serialize (obj hash-table)
+  nil)
+
+(defmethod %%deserialize-struct (type payload)
+  nil)

--- a/update_python_spec.lisp
+++ b/update_python_spec.lisp
@@ -1,0 +1,11 @@
+#!/usr/bin/env sbcl --script
+(load "~/.sbclrc")
+(ql:quickload :rpcq)
+(rpcq::clear-messages)
+(load "src/messages.lisp")
+(with-open-file (f "rpcq/messages.py"
+                   :direction ':output
+                   :if-exists ':supersede) 
+  (rpcq::python-message-spec f)
+  (write-line "Wrote new message spec."))
+


### PR DESCRIPTION
This branch contains some new features at the message declaration level: message inheritance and field deprecation. Additionally, following a template laid out by @stevenheidel , this branch contains a python message generator that uses python3 dataclasses.

It's not ready for prime time:

* The handling of deprecated optional fields in the python3 output is not very good.
* It doesn't sort optional/required fields in the python3 output, so previously functioning message definitions generate bad output.

It is ready for comment, though.