### PR TITLE
Fixes to Lisp message serialization

### DIFF
--- a/src/client.lisp
+++ b/src/client.lisp
@@ -91,7 +91,8 @@
       (process-args args)
       (alexandria:plist-hash-table
        (list "*args" *args
-             "**kwargs" **kwargs)))))
+             "**kwargs" **kwargs)
+       :test #'equal))))
 
 (defun rpc-call (client call &rest args)
   "Makes a synchronous RPC call, designated by the string method name CALL, over the connection CLIENT.  ARGS is a plist of arguments.  Returns the result of the call directly."

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -65,23 +65,33 @@
 
 
 (defun prepare-rpc-call-args (args)
-  (cond
-    ((null args)
-     (alexandria:plist-hash-table (list "*args" '()
-                                        "**kwargs" (make-hash-table :test #'equal))))
-    (t
-     (let ((**kwargs (make-hash-table :test #'equal)))
-       (loop :for arg :in args
-             :for rest := args :then (rest rest)
-             :if (keywordp arg)
-               :return (progn
-                         (loop :for (key val) :on rest :by #'cddr :while val
-                               :do (setf (gethash (sanitize-name key) **kwargs) val))
-                         (alexandria:plist-hash-table (list "*args" *args
-                                                            "**kwargs" **kwargs)
-                                                      :test #'equal))
-             :else
-               :collect arg :into *args)))))
+  (let ((*args (list))
+        (**kwargs (make-hash-table :test #'equal)))
+    (labels
+        ((process-args (args)
+           (cond
+             ((null args)
+              t)
+             ((keywordp (first args))
+              (process-**kwargs args))
+             (t
+              (push (first args) *args)
+              (process-args (rest args)))))
+         
+         (process-**kwargs (args)
+           (cond
+             ((null args)
+              t)
+             (t
+              (let ((key (sanitize-name (first args)))
+                    (val (second args)))
+                (setf (gethash key **kwargs) val)
+                (process-**kwargs args))))))
+      
+      (process-args args)
+      (alexandria:plist-hash-table
+       (list "*args" *args
+             "**kwargs" **kwargs)))))
 
 (defun rpc-call (client call &rest args)
   "Makes a synchronous RPC call, designated by the string method name CALL, over the connection CLIENT.  ARGS is a plist of arguments.  Returns the result of the call directly."

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -66,6 +66,16 @@ The input strings are assumed to be FORMAT-compatible, so sequences like ~<newli
 (defmethod %serialize (payload)
   payload)
 
+(defmethod %serialize ((payload cons))
+  (loop :for elt :in payload :collect (%serialize elt)))
+
+(defmethod %serialize ((payload hash-table))
+  (let ((hash (make-hash-table :test #'equal)))
+    (loop :for k :being :the :hash-keys :of payload
+          :using (hash-value v)
+          :do (setf (gethash k hash) (%serialize v)))
+    hash))
+
 (defgeneric %deserialize (payload)
   (:documentation "Reconstruct objects that have already been converted to Lisp objects."))
 

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -73,7 +73,7 @@ The input strings are assumed to be FORMAT-compatible, so sequences like ~<newli
   (let ((hash (make-hash-table :test #'equal)))
     (loop :for k :being :the :hash-keys :of payload
           :using (hash-value v)
-          :do (setf (gethash k hash) (%serialize v)))
+          :do (setf (gethash (%serialize k) hash) (%serialize v)))
     hash))
 
 (defgeneric %deserialize (payload)


### PR DESCRIPTION
Fixes for two "minor" (but blocking) bugs in the serialization of Lisp RPC client calls:

* For messages wrapped in standard Lisp container types (lists, hash tables), walk over the entries of the containers with the RPCQ serializer before handing off to msgpack.
* Rewrite the *args/**kwargs untangler, which previously had a bug in the *args-only case.