### PR TITLE
add missing dataclasses req to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,13 +43,13 @@ setup(
     description='''The RPC framework and message specification for Rigetti QCS.''',
     long_description=long_description,
     install_requires=[
+        'dataclasses;python_version<="3.6"',
         'future',
         'msgpack>=0.5.2',
         'python-rapidjson',
         'pyzmq>=17',
         'ruamel.yaml',
         'typing',
-        'dataclasses
     ],
     keywords='quantum rpc qcs',
     python_requires='>=3.5',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'python-rapidjson',
         'pyzmq>=17',
         'ruamel.yaml',
-        'typing',
+        'typing'
     ],
     keywords='quantum rpc qcs',
     python_requires='>=3.5',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         'python-rapidjson',
         'pyzmq>=17',
         'ruamel.yaml',
-        'typing'
+        'typing',
+        'dataclasses
     ],
     keywords='quantum rpc qcs',
     python_requires='>=3.5',


### PR DESCRIPTION
Found this missing after a fresh `pip install`