### PR TITLE
randomize Lisp server's internal endpoint name

### DIFF
--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -23,8 +23,8 @@
                               `(:array :uint8 ,(pzmq:msg-size msg))))
 
 (defun global-function-p (symbol)
-  "Return true if SYMBOL names a global function. Return false if it doesn't."
-  (check-type symbol symbol)
-  (and (fboundp symbol)
+  "Return true if SYMBOL is a symbol naming a global function. Return false otherwise."
+  (and (typep symbol 'symbol)
+       (fboundp symbol)
        (not (macro-function symbol))
        (not (special-operator-p symbol))))


### PR DESCRIPTION
The Lisp server communicates with its worker threads over an `inproc` ZMQ connection whose address used to be fixed at `inproc://workers`. This breaks applications that want to run more than one server simultaneously, which was a use case we recently brushed up against. This fix randomizes the internal endpoint name using the already-loaded `unicly` module.

I'm also trying to sneak in a second change where dispatch handlers are allowed to be anonymous functions. I suspect this will be more controversial; feel free to come at me about it.