### PR TITLE
Use CL-SYSLOG for logging

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -28,6 +28,7 @@
                #:bordeaux-threads       ; threaded RPC server
                #:local-time             ; local time for logs
                #:unicly                 ; UUID generation
+               #:cl-syslog              ; send logs to syslogd
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:rpcq-tests)))
   :pathname "src/"

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -223,7 +223,8 @@ DISPATCH-TABLE and LOGGING-STREAM are both required arguments.  TIMEOUT is of ty
                        dispatch-table
                        (listen-addresses (list "tcp://*:5555"))
                        (thread-count 5)
-                       (logger (make-instance 'cl-syslog:rfc5424-logger))
+                       (logger (make-instance 'cl-syslog:rfc5424-logger
+                                              :log-writer (cl-syslog:null-log-writer)))
                        timeout)
   "Main loop of an RPCQ server.
 

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -140,6 +140,13 @@ By default, a symbol passed in for F will be automatically converted into the na
                      (unknown-rpc-method-name condition)))))
 
 
+(cl-syslog:define-structured-data-id |rigetti@0000| ()
+  |methodName|
+  |requestID|
+  |wallTime|
+  |error|)
+
+
 (defun %rpc-server-thread-worker (&key
                                     dispatch-table
                                     logger
@@ -152,67 +159,84 @@ DISPATCH-TABLE and LOGGING-STREAM are both required arguments.  TIMEOUT is of ty
     (pzmq:connect receiver pool-address)
     (loop
       (handler-case
-          (let (request result reply)
-            (multiple-value-bind (identity empty-frame raw-request)
-                (%pull-raw-request receiver)
-              (handler-case
-                  (progn
-                    (setf request (deserialize raw-request))
-                    (unless (typep request '|RPCRequest|)
-                      (error 'not-an-rpcrequest
-                             :object request))
-                    (cl-syslog:format-log logger ':info
-                                          "Got request: ~a" (|RPCRequest-method| request))
-                    
-                    (let ((kwargs-as-plist
-                            (if (gethash "**kwargs" (|RPCRequest-params| request))
-                                (loop :for key :being :the :hash-keys :of (gethash "**kwargs" (|RPCRequest-params| request))
-                                        :using (hash-value val)
-                                      :collect (str->lisp-keyword key)
-                                      :collect val)
-                                nil))
-                          (args-as-list (gethash "*args" (|RPCRequest-params| request))))
-                      (let ((f (gethash (|RPCRequest-method| request) dispatch-table)))
-                        (unless f
-                          (error 'unknown-rpc-method
-                                 :method-name (|RPCRequest-method| request)))
-                        (setf result 
-                              (if timeout
-                                  (bt:with-timeout (timeout)
-                                    (apply f (append args-as-list kwargs-as-plist)))
-                                  (apply f (append args-as-list kwargs-as-plist))))
-                        
-                        (setf reply (make-instance '|RPCReply|
-                                                   :|id| (|RPCRequest-id| request)
-                                                   :|result| result))))
-                    (cl-syslog:format-log logger ':info
-                                          "Finishing request: ~a" (|RPCRequest-method| request)))
+          (let (request result reply start-time)
+            (macrolet ((log-completion-message (priority control &rest args)
+                         `(cl-syslog:rfc-log (logger ,priority ,control ,@args)
+                            (:msgid "LOG0002")
+                            (|rigetti@0000|
+                             |methodName| (|RPCRequest-method| request)
+                             |requestID| (|RPCRequest-id| request)
+                             |wallTime| (format nil "~f" (/ (- (get-internal-real-time) start-time)
+                                                            internal-time-units-per-second))
+                             |error| ,(if (<= (cdr (assoc priority cl-syslog::*priorities*))
+                                              (cdr (assoc ':err cl-syslog::*priorities*)))
+                                          "true"
+                                          "false")))))
+              (multiple-value-bind (identity empty-frame raw-request)
+                  (%pull-raw-request receiver)
+                (handler-case
+                    (progn
+                      (setf start-time (get-internal-real-time))
+                      (setf request (deserialize raw-request))
+                      (unless (typep request '|RPCRequest|)
+                        (error 'not-an-rpcrequest
+                               :object request))
+                      (cl-syslog:format-log logger ':info
+                                            "Request ~a received for ~a"
+                                            (|RPCRequest-id| request)
+                                            (|RPCRequest-method| request))
+                      
+                      (let ((kwargs-as-plist
+                              (if (gethash "**kwargs" (|RPCRequest-params| request))
+                                  (loop :for key :being :the :hash-keys :of (gethash "**kwargs" (|RPCRequest-params| request))
+                                          :using (hash-value val)
+                                        :collect (str->lisp-keyword key)
+                                        :collect val)
+                                  nil))
+                            (args-as-list (gethash "*args" (|RPCRequest-params| request))))
+                        (let ((f (gethash (|RPCRequest-method| request) dispatch-table)))
+                          (unless f
+                            (error 'unknown-rpc-method
+                                   :method-name (|RPCRequest-method| request)))
+                          (setf result 
+                                (if timeout
+                                    (bt:with-timeout (timeout)
+                                      (apply f (append args-as-list kwargs-as-plist)))
+                                    (apply f (append args-as-list kwargs-as-plist))))
+                          
+                          (setf reply (make-instance '|RPCReply|
+                                                     :|id| (|RPCRequest-id| request)
+                                                     :|result| result))))
+                      (log-completion-message :info "Requested ~a completed" (|RPCRequest-method| request)))
+                  
+                  ;; this is where errors go where we can reply to the client
+                  (unknown-rpc-method (c)
+                    (declare (ignore c))
+                    (log-completion-message :err "Request ~a error: method ~a unknown"
+                                            (|RPCRequest-id| request)
+                                            (|RPCRequest-method| request))
+                    (setf reply (make-instance '|RPCError|
+                                               :|id| (|RPCRequest-id| request)
+                                               :|error| (format nil "Method named \"~a\" is unknown."
+                                                                (|RPCRequest-method| request)))))
+                  (bt:timeout (c)
+                    (declare (ignore c))
+                    (log-completion-message :err "Request ~a error: timed out"
+                                            (|RPCRequest-id| request))
+                    (setf reply (make-instance '|RPCError|
+                                               :|id| (|RPCRequest-id| request)
+                                               :|error| (format nil "Execution timed out.  Note: time limit: ~a seconds." timeout))))
+                  (error (c)
+                    (log-completion-message :err
+                                            "Request ~a error: Unhandled error in host program:~%~a"
+                                            (|RPCRequest-id| request)
+                                            c)
+                    (setf reply (make-instance '|RPCError|
+                                               :|id| (|RPCRequest-id| request)
+                                               :|error| (format nil "~a" c)))))
                 
-                ;; this is where errors go where we can reply to the client
-                (unknown-rpc-method (c)
-                  (declare (ignore c))
-                  (cl-syslog:format-log logger ':error
-                                        "Error: method ~a unknown" (|RPCRequest-method| request))
-                  (setf reply (make-instance '|RPCError|
-                                             :|id| (|RPCRequest-id| request)
-                                             :|error| (format nil "Method named \"~a\" is unknown."
-                                                              (|RPCRequest-method| request)))))
-                (bt:timeout (c)
-                  (declare (ignore c))
-                  (cl-syslog:format-log logger ':error
-                                        "Timed out on request ~a" (|RPCRequest-method| request))
-                  (setf reply (make-instance '|RPCError|
-                                             :|id| (|RPCRequest-id| request)
-                                             :|error| (format nil "Execution timed out.  Note: time limit: ~a seconds." timeout))))
-                (error (c)
-                  (cl-syslog:format-log logger ':error
-                                        "Unhandled error during RPC call:~%~a" c)
-                  (setf reply (make-instance '|RPCError|
-                                             :|id| (|RPCRequest-id| request)
-                                             :|error| (format nil "~a" c)))))
-              
-              ;; send the client response, whether success or failure
-              (%push-raw-request receiver identity empty-frame (serialize reply))))
+                ;; send the client response, whether success or failure
+                (%push-raw-request receiver identity empty-frame (serialize reply)))))
         
         ;; this is where errors go where we can't even reply to the client
         (simple-error (c)


### PR DESCRIPTION
Rather than making up a logging format, let's use RFC5424.

Depends on https://github.com/mmaul/cl-syslog/pull/8 .

Room for improvement:
* Are the log levels set appropriately for those different error cases?
* Should we suffer through backwards compatibility with the `:logging-stream` key?
* I'd like the start/finish info messages to contain the request ID. Seems like a natural use case for structured data, if I knew how to do that.