### PR TITLE
Change latest and stable Docker image tag convention

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ test-lisp:
     - make install-test-deps
     - make test
 
-docker-master:
+docker-edge:
   stage: package
   tags:
     - dockerd
@@ -33,9 +33,9 @@ docker-master:
     - master
   image: docker:stable
   script:
-    - docker build --tag rigetti/rpcq:${CI_COMMIT_SHORT_SHA} --tag rigetti/rpcq:latest .
+    - docker build --tag rigetti/rpcq:${CI_COMMIT_SHORT_SHA} --tag rigetti/rpcq:edge .
     - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/rpcq && docker rmi -f rigetti/rpcq:latest
+    - docker push rigetti/rpcq && docker rmi -f rigetti/rpcq:edge
 
 docker-branch:
   stage: package
@@ -52,7 +52,7 @@ docker-branch:
     - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
     - docker push rigetti/rpcq && docker rmi -f rigetti/rpcq:${CI_COMMIT_REF_SLUG}
 
-docker-vtag:
+docker-stable:
   stage: package
   tags:
     - dockerd

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Implements an efficient transport protocol by using [ZeroMQ](http://zeromq.org/)
 Not intended to be a full-featured replacement for other frameworks like
 [gRPC](https://grpc.io/) or [Apache Thrift](https://thrift.apache.org/).
 
-python Installation
+Python Installation
 -------------------
 
 To install directly from the source, run `pip install -e .` from within the top-level
@@ -118,12 +118,12 @@ open `rlwrap sbcl` and run:
 Running the Unit Tests
 ----------------------
 
-The `rpcq` repository is configured with SemaphoreCI to automatically run the Python unit tests.
-This can be done locally by running `pytest` from the top-level directory of the repository
-(assuming you have installed the test requirements).
+The `rpcq` repository is configured with GitLab CI to automatically run the unit tests.
 
-There is additionally a very small suite of Lisp tests for `rpcq`. These are not run by
-SemaphoreCI, but can be run locally by doing the following from within `rlwrap sbcl`:
+The Python unit tests can be executed locally by running `pytest` from the top-level
+directory of the repository (assuming you have installed the test requirements).
+
+The Lisp unit tests can be run locally by doing the following from within `rlwrap sbcl`:
 
 ```lisp
 (ql:quickload :rpcq)
@@ -137,6 +137,13 @@ there should be something near the bottom of the output that looks like:
 RPCQ-TESTS (Suite)
   TEST-DEFMESSAGE                                                         [ OK ]
 ```
+
+Automated Packaging with Docker
+-------------------------------
+
+The CI pipeline for `rpcq` produces a Docker image, available at
+[`rigetti/rpcq`](https://hub.docker.com/r/rigetti/rpcq). To get the latest stable
+version of `rpcq`, run `docker pull rigetti/rpcq`.
 
 Authors
 -------


### PR DESCRIPTION
Now that we are beginning to open source Docker images, it is time to change the convention for the `latest` (default) tag. Previously, we have had this track the tip of `master`, but it is more sensible to have this track the latest stable version, along with `stable`. The tag that tracks the tip of `master` will now be called `edge` (this is practice that Docker itself follows in tagging the `docker` Docker image). This will guarantee that downstream builds that build `FROM rigetti/rpcq` will pull a stable version of the software, rather than a bleeding edge one.

Also, there is now useful information about this distinction available on the `rigetti/rpcq` DockerHub page itself: https://hub.docker.com/r/rigetti/rpcq