### PR TITLE
Remove docker-related jobs and include them from rigetti/ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,9 +10,11 @@ test-python:
   tags:
     - github
   only:
-    - branches
+    refs:
+      - branches
   image: python:3.6
   script:
+    - python --version
     - pip install -r requirements.txt
     - pytest
 
@@ -21,8 +23,10 @@ test-lisp:
   tags:
     - github
   only:
-    - branches
+    refs:
+      - branches
   image: rigetti/quicklisp
   script:
+    - sbcl --version
     - make install-test-deps
     - make test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,6 @@ include:
 variables:
   IMAGE: rigetti/rpcq
 
-stages:
-  - test
-  - package
-
 test-python:
   stage: test
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,9 +2,6 @@ include:
   - project: rigetti/ci
     file: pipelines/docker.gitlab-ci.yml
 
-variables:
-  IMAGE: rigetti/rpcq
-
 test-python:
   stage: test
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,10 @@
+include:
+  - project: rigetti/ci
+    file: pipelines/docker.gitlab-ci.yml
+
+variables:
+  IMAGE: rigetti/rpcq
+
 stages:
   - test
   - package
@@ -23,50 +30,3 @@ test-lisp:
   script:
     - make install-test-deps
     - make test
-
-docker-edge:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  only:
-    - master
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/rpcq:${CI_COMMIT_SHORT_SHA} --tag rigetti/rpcq:edge .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/rpcq && docker rmi -f rigetti/rpcq:edge
-
-docker-branch:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  only:
-    - branches
-  except:
-    - master
-  image: docker:stable
-  script:
-    - docker build --tag rigetti/rpcq:${CI_COMMIT_REF_SLUG} .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/rpcq && docker rmi -f rigetti/rpcq:${CI_COMMIT_REF_SLUG}
-
-docker-stable:
-  stage: package
-  tags:
-    - dockerd
-    - github
-  # matches only on tags of the form vX.Y.Z
-  only:
-    - /^v(\d+\.)?(\d+\.)?(\d+)$/
-  except:
-    - branches
-  image: docker:stable
-  script:
-    - export VERSION=`cat VERSION.txt`
-    # make sure tag matches VERSION.txt
-    - if [ "${CI_COMMIT_TAG}" = "v${VERSION}" ]; then return 0; else return 1; fi
-    - docker build --tag rigetti/rpcq:$VERSION --tag rigetti/rpcq:stable --tag rigetti/rpcq:latest .
-    - echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-    - docker push rigetti/rpcq && docker rmi -f rigetti/rpcq:stable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ include:
   - project: rigetti/ci
     file: pipelines/docker.gitlab-ci.yml
 
+variables:
+  IMAGE: rigetti/rpcq
+
 test-python:
   stage: test
   tags:


### PR DESCRIPTION
Leveraging the [`include`](https://docs.gitlab.com/ee/ci/yaml/#include) functionality of the GitLab CI YAML to remove build code duplication across our various repos. See the included YAML/pipeline here: https://github.com/rigetti/ci/blob/master/pipelines/docker.gitlab-ci.yml

Pretty cool stuff!

This can be made even more robust, but I think it's a good first step.