### PR TITLE
stricter types, UTF8 encode/decode

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -29,6 +29,7 @@
                #:local-time             ; local time for logs
                #:unicly                 ; UUID generation
                #:cl-syslog              ; send logs to syslogd
+               #:flexi-streams          ; UTF8 encode/decode
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:rpcq-tests)))
   :pathname "src/"


### PR DESCRIPTION
This commit makes some types a little bit stronger, and does proper
UTF8 encode/decode of strings.