### PR TITLE
patch up imports + underscore core_messages

### DIFF
--- a/rpcq/core_messages.py
+++ b/rpcq/core_messages.py
@@ -6,6 +6,7 @@ WARNING: This file is auto-generated, do not edit by hand. See README.md.
 
 from warnings import warn
 from rpcq._base import Message
+from rpcq.messages import ParameterSpec, PatchTarget
 from dataclasses import dataclass, field, InitVar
 from typing import Any, List, Dict, Optional, Union, Tuple
 


### PR DESCRIPTION
Importing from `rpcq.core_messages` previously failed due to missing imports in `core_messages`. This PR adds ParameterSpec, PatchTarget to `core_messages` - now import succeeds.