### PR TITLE
Add some shields.io badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ rpcq
 ====
 
 [![pipeline status](https://gitlab.com/rigetti/forest/rpcq/badges/master/pipeline.svg)](https://gitlab.com/rigetti/forest/rpcq/commits/master)
-[![pypi](https://img.shields.io/pypi/v/rpcq.svg)](https://pypi.org/project/rpcq/)
+[![pypi version](https://img.shields.io/pypi/v/rpcq.svg)](https://pypi.org/project/rpcq/)
+[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/rpcq.svg)](https://anaconda.org/conda-forge/rpcq)
 [![docker pulls](https://img.shields.io/docker/pulls/rigetti/rpcq.svg)](https://hub.docker.com/r/rigetti/rpcq)
 
 The asynchronous RPC client-server framework and message specification for

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ rpcq
 ====
 
 [![pipeline status](https://gitlab.com/rigetti/forest/rpcq/badges/master/pipeline.svg)](https://gitlab.com/rigetti/forest/rpcq/commits/master)
+[![docker pulls](https://img.shields.io/docker/pulls/rigetti/rpcq.svg)](https://hub.docker.com/r/rigetti/rpcq)
 
 The asynchronous RPC client-server framework and message specification for
 [Rigetti Quantum Cloud Services (QCS)](https://www.rigetti.com/).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ rpcq
 ====
 
 [![pipeline status](https://gitlab.com/rigetti/forest/rpcq/badges/master/pipeline.svg)](https://gitlab.com/rigetti/forest/rpcq/commits/master)
+[![pypi](https://img.shields.io/pypi/v/rpcq.svg)](https://pypi.org/project/rpcq/)
 [![docker pulls](https://img.shields.io/docker/pulls/rigetti/rpcq.svg)](https://hub.docker.com/r/rigetti/rpcq)
 
 The asynchronous RPC client-server framework and message specification for


### PR DESCRIPTION
PyPI version, conda-forge version, and docker pulls. We could also put the rigetti conda channel version, but methinks it starts to get a little crowded.