### PR TITLE
uuid: get rid of unicly dependency

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -27,7 +27,7 @@
                #:cl-messagepack         ; message packer
                #:bordeaux-threads       ; threaded RPC server
                #:local-time             ; local time for logs
-               #:unicly                 ; UUID generation
+               #:uuid                   ; UUID generation
                #:cl-syslog              ; send logs to syslogd
                #:flexi-streams          ; UTF8 encode/decode
                )

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -96,7 +96,7 @@
 
 (defun rpc-call (client call &rest args)
   "Makes a synchronous RPC call, designated by the string method name CALL, over the connection CLIENT.  ARGS is a plist of arguments.  Returns the result of the call directly."
-  (let* ((uuid (unicly:uuid-princ-to-string (unicly:make-v4-uuid)))
+  (let* ((uuid (format nil "~a" (uuid:make-v4-uuid)))
          (request (make-instance '|RPCRequest|
                                  :|id| uuid
                                  :|params| (prepare-rpc-call-args args)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -278,7 +278,7 @@ Argument descriptions:
   (check-type thread-count (integer 1))
   (check-type timeout (or null (real 0)))
   (check-type listen-addresses list)
-  (let ((pool-address (format nil "inproc://~a" (unicly:make-v4-uuid))))
+  (let ((pool-address (format nil "inproc://~a" (uuid:make-v4-uuid))))
     (cl-syslog:format-log logger ':info
                           "Spawning server at ~a .~%" listen-addresses)
     (pzmq:with-sockets ((clients :router :monitor) (workers :dealer :monitor))


### PR DESCRIPTION
Unicly is written in a very messy manner, hard to port and seemingly
unmaintained. UUID may be used as a drop-in replacement which works
portably across wider range of implementations.