### PR TITLE
add rpcq.messages as a parent namespace to rpcq.core_messages

### DIFF
--- a/rpcq/core_messages.py
+++ b/rpcq/core_messages.py
@@ -8,7 +8,6 @@ import sys
 
 from warnings import warn
 from rpcq._base import Message
-from rpcq.messages import ParameterSpec, PatchTarget
 from typing import Any, List, Dict, Optional
 
 if sys.version_info < (3, 7):
@@ -16,6 +15,7 @@ if sys.version_info < (3, 7):
 else:
     from dataclasses import dataclass, field, InitVar
 
+from rpcq.messages import *
 
 @dataclass(eq=False, repr=False)
 class Frame(Message):

--- a/src/rpcq-python.lisp
+++ b/src/rpcq-python.lisp
@@ -158,7 +158,6 @@ import sys
 
 from warnings import warn
 from rpcq._base import Message
-from rpcq.messages import ParameterSpec, PatchTarget
 from typing import Any, List, Dict, Optional
 
 if sys.version_info < (3, 7):

--- a/update_python_spec.lisp
+++ b/update_python_spec.lisp
@@ -3,12 +3,15 @@
 (ql:quickload :rpcq)
 (rpcq::clear-messages)
 
-(dolist (namespace '("messages" "core-messages"))
-  (load (make-pathname :name namespace :type "lisp" :directory '(:relative "src")))
-  (let ((path (make-pathname :name (rpcq::sanitize-name namespace) :type "py" :directory '(:relative "rpcq"))))
-    (with-open-file (f path
-                     :direction ':output
-                     :if-exists ':supersede
-                     :if-does-not-exist ':create)
-      (rpcq::python-message-spec f (gethash namespace rpcq::*messages*))
-      (format t "Wrote new ~A.py~%" (pathname-name path)))))
+(dolist (namespace-and-parents '(;; table of pairs: (module-name (parent-module-python-name1 ...))
+                                 ("messages" nil)
+                                 ("core-messages" ("rpcq.messages"))))
+  (destructuring-bind (namespace parent-namespaces) namespace-and-parents
+    (load (make-pathname :name namespace :type "lisp" :directory '(:relative "src")))
+    (let ((path (make-pathname :name (rpcq::sanitize-name namespace) :type "py" :directory '(:relative "rpcq"))))
+      (with-open-file (f path
+                         :direction ':output
+                         :if-exists ':supersede
+                         :if-does-not-exist ':create)
+        (rpcq::python-message-spec f (gethash namespace rpcq::*messages*) parent-namespaces)
+        (format t "Wrote new ~A.py~%" (pathname-name path))))))


### PR DESCRIPTION
This PR add `rpcq.messages` as a dependency of `rpcq.core_messages`, removing the manual import of `ParameterSpec` and `PatchTarget`.

This is a minimal fix. It uses existing code paths in RPCQ—but on inspection, these code paths don't seem that great to me: this dependency gets recorded in that generation utility file instead of in mainline RPCQ, and the name `rpcq.messages` is Python-specific, rather than letting the code generator figure out what's right for the desired output language.