### PR TITLE
Serialize rationals as floats

### DIFF
--- a/src-tests/suite.lisp
+++ b/src-tests/suite.lisp
@@ -73,9 +73,11 @@
 (deftest test-serialize-deserialize ()
   (let* ((original (make-instance 'rpcq::|RPCRequest|
                                   :|method| "test-method"
-                                  :|params| (make-hash-table)
+                                  :|params| (alexandria:alist-hash-table
+                                             '(("one-half" . 1/2)))
                                   :|id| "test-id"))
          (cloned (rpcq::deserialize (rpcq::serialize original))))
     (is (typep cloned 'rpcq::|RPCRequest|))
     (is (string= (rpcq::|RPCRequest-id| original)     (rpcq::|RPCRequest-id| cloned)))
-    (is (string= (rpcq::|RPCRequest-method| original) (rpcq::|RPCRequest-method| cloned)))))
+    (is (string= (rpcq::|RPCRequest-method| original) (rpcq::|RPCRequest-method| cloned)))
+    (is (= 0.5 (gethash "one-half" (rpcq::|RPCRequest-params| cloned))))))

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -95,6 +95,9 @@ The input strings are assumed to be FORMAT-compatible, so sequences like ~<newli
 (defmethod %serialize ((payload string))
   payload)
 
+(defmethod %serialize ((payload rational))
+  (%serialize (float payload)))
+
 (defmethod %serialize ((payload hash-table))
   (let ((hash (make-hash-table :test #'equal)))
     (loop :for k :being :the :hash-keys :of payload


### PR DESCRIPTION
Deserializing also produces floats.

Closes #23.