### PR TITLE
Do not store "**kwargs" as distinct entry in params dictionary

### DIFF
--- a/src/client.lisp
+++ b/src/client.lisp
@@ -87,12 +87,9 @@
                     (val (second args)))
                 (setf (gethash key **kwargs) val)
                 (process-**kwargs (rest (rest args))))))))
-      
       (process-args args)
-      (alexandria:plist-hash-table
-       (list "*args" *args
-             "**kwargs" **kwargs)
-       :test #'equal))))
+      (setf (gethash "*args" **kwargs) *args)
+      **kwargs)))
 
 (defun rpc-call (client call &rest args)
   "Makes a synchronous RPC call, designated by the string method name CALL, over the connection CLIENT.  ARGS is a plist of arguments.  Returns the result of the call directly."


### PR DESCRIPTION
This aligns the (currently `i n c o m m e n s u r a t e`) behaviours of pyQuil and quilc. Given a dictionary of keyword arguments `**kwargs` and a dictionary of positional arguments `*args`,

  * `client.lisp` would (before this change) produce (and `server.lisp` would expect) a dictionary like: `{"*args": *args, "**kwargs": **kwargs}`.

  * `client.py` will produce a dictionary like: `{"*args": *args, kwarg1-str: kwarg1-val, kwarg2-str: kwarg2-val, ...}` etc.

The alternative is to make the python implementation match the current lisp implementation, but changing the lisp code seems less likely to cause BC issues.