### PR TITLE
Use new rigetti/lisp image for testing and Docker build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ test-lisp:
   only:
     refs:
       - branches
-  image: rigetti/quicklisp
+  image: rigetti/lisp:2019-07-11
   script:
     - sbcl --version
     - make install-test-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rigetti/quicklisp
+FROM rigetti/lisp:2019-07-11
 
 # install build dependencies
 COPY Makefile /src/rpcq/Makefile

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Running the Unit Tests
 ----------------------
 
 The `rpcq` repository is configured with GitLab CI to automatically run the unit tests.
+The tests run within a container based off of the
+[`rigetti/lisp`](https://hub.docker.com/r/rigetti/lisp) Docker image, which is pinned to a specific
+tag. If you need a more recent version of the image, update the tag in the `.gitlab-ci.yml`.
 
 The Python unit tests can be executed locally by running `pytest` from the top-level
 directory of the repository (assuming you have installed the test requirements).
@@ -153,7 +156,12 @@ Automated Packaging with Docker
 
 The CI pipeline for `rpcq` produces a Docker image, available at
 [`rigetti/rpcq`](https://hub.docker.com/r/rigetti/rpcq). To get the latest stable
-version of `rpcq`, run `docker pull rigetti/rpcq`.
+version of `rpcq`, run `docker pull rigetti/rpcq`. The image is built from the
+[`rigetti/lisp`](https://hub.docker.com/r/rigetti/lisp) Docker image, which is pinned to a specific
+tag. If you need a more recent version of the image, update the tag in the `Dockerfile`.
+
+To learn more about the `rigetti/lisp` Docker image, check out the
+[`docker-lisp`](https://github.com/rigetti/docker-lisp) repository.
 
 Release Process
 ---------------


### PR DESCRIPTION
Check out the [`rigetti/lisp`](https://hub.docker.com/r/rigetti/lisp) DockerHub page and the [`docker-lisp`](https://github.com/rigetti/docker-lisp) GitHub repository for more info.