### PR TITLE
Don't reverse the order of non-keyword args in PREPARE-RPC-CALL-ARGS

### DIFF
--- a/src/client.lisp
+++ b/src/client.lisp
@@ -88,7 +88,7 @@
                 (setf (gethash key **kwargs) val)
                 (process-**kwargs (rest (rest args))))))))
       (process-args args)
-      (setf (gethash "*args" **kwargs) *args)
+      (setf (gethash "*args" **kwargs) (nreverse *args))
       **kwargs)))
 
 (defun rpc-call (client call &rest args)

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -65,19 +65,16 @@
 
 
 (defun prepare-rpc-call-args (args)
-  (let ((*args (list))
-        (**kwargs (make-hash-table :test #'equal)))
+  (let ((**kwargs (make-hash-table :test #'equal)))
     (labels
-        ((process-args (args)
+        ((process-args (args *args)
            (cond
-             ((null args)
-              t)
-             ((keywordp (first args))
+             ((or (null args) (keywordp (first args)))
+              (setf (gethash "*args" **kwargs) (reverse *args))
               (process-**kwargs args))
              (t
-              (push (first args) *args)
-              (process-args (rest args)))))
-         
+              (process-args (rest args) (cons (first args) *args)))))
+
          (process-**kwargs (args)
            (cond
              ((null args)
@@ -87,8 +84,7 @@
                     (val (second args)))
                 (setf (gethash key **kwargs) val)
                 (process-**kwargs (rest (rest args))))))))
-      (process-args args)
-      (setf (gethash "*args" **kwargs) (nreverse *args))
+      (process-args args '())
       **kwargs)))
 
 (defun rpc-call (client call &rest args)


### PR DESCRIPTION
Don't reverse the order of non-keyword args in `PREPARE-RPC-CALL-ARGS`

Prior to this change, an rpc call like

    (rpcq:rcp-call client "my-func" 1 2 3 :four 4)

would result in the handler for "my-func" getting called with arguments `'(3 2 1 "four" 4)`, rather than `'(1 2 3 "four" 4)`.