### PR TITLE
add core-messages to lisp system

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -38,6 +38,7 @@
                (:file "utilities")
                (:file "rpcq")
                (:file "rpcq-python")
+               (:file "core-messages")
                (:file "messages")
                (:file "server")
                (:file "client")))


### PR DESCRIPTION
Unless this was intentionally omitted, we might as well include these.