### PR TITLE
Add option to log backtraces on handler error

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -30,6 +30,7 @@
                #:uuid                   ; UUID generation
                #:cl-syslog              ; send logs to syslogd
                #:flexi-streams          ; UTF8 encode/decode
+               #:trivial-backtrace      ; logging backtraces
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:rpcq-tests)))
   :pathname "src/"

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -159,3 +159,36 @@
               :do (sleep 1) (bt:destroy-thread server-thread))
         #-ccl
         (bt:destroy-thread server-thread)))))
+
+(defun test-error-method ()
+  (error "oof!"))
+
+(deftest test-log-backtrace ()
+  (with-unique-rpc-address (addr)
+    (let* ((log-stream (make-string-output-stream))
+           (server-function
+             (lambda ()
+               (let ((dt (rpcq:make-dispatch-table)))
+                 (rpcq:dispatch-table-add-handler dt 'test-error-method)
+                 (rpcq:start-server :dispatch-table dt
+                                    :listen-addresses (list addr)
+                                    :debug t
+                                    :logger (make-instance 'cl-syslog:rfc5424-logger
+                                                           :app-name "rpcq-tests"
+                                                           :facility ':local0
+                                                           :maximum-priority ':err
+                                                           :log-writer
+                                                           (cl-syslog:stream-log-writer log-stream))))))
+           (server-thread (bt:make-thread server-function)))
+      (sleep 1)
+      (unwind-protect
+           (rpcq:with-rpc-client (client addr)
+             (signals rpcq::rpc-error
+               (rpcq:rpc-call client "test-error-method"))
+             (is (search "TRIVIAL-BACKTRACE:PRINT-BACKTRACE" (get-output-stream-string log-stream))))
+        ;; kill the server thread
+        #+ccl
+        (loop :while (bt:thread-alive-p server-thread)
+              :do (sleep 1) (bt:destroy-thread server-thread))
+        #-ccl
+        (bt:destroy-thread server-thread)))))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -213,7 +213,7 @@ DISPATCH-TABLE and LOGGING-STREAM are both required arguments.  TIMEOUT is of ty
                                                         :|result| result
                                                         :|warnings| warnings))))
                          (log-completion-message :info "Requested ~a completed" (|RPCRequest-method| request)))
-                     
+
                      ;; this is where errors go where we can reply to the client
                      (unknown-rpc-method (c)
                        (declare (ignore c))
@@ -242,14 +242,14 @@ DISPATCH-TABLE and LOGGING-STREAM are both required arguments.  TIMEOUT is of ty
                                                   :|id| (|RPCRequest-id| request)
                                                   :|error| (princ-to-string c)
                                                   :|warnings| warnings))))
-                   
+
                    ;; send the client response, whether success or failure
                    (handler-case
                        (%push-raw-request receiver identity empty-frame (serialize reply))
                      (error (c)
                        (cl-syslog:format-log logger ':err
                                              "Threw generic error after RPC call, during reply encoding:~%~a" c)))))))
-        
+
          ;; this is where errors go where we can't even reply to the client
          (error (c)
            (cl-syslog:format-log logger ':err


### PR DESCRIPTION
Add a `:DEBUG` keyword argument to `RPCQ:START-SERVER`. If non-nil, log a backtrace when the handler throws an error.

Also adds a test for `UNKNOWN-METHOD-ERROR` because why not?

Closes #87