### PR TITLE
Add option to log backtraces on handler error (for real this time)

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -30,6 +30,7 @@
                #:uuid                   ; UUID generation
                #:cl-syslog              ; send logs to syslogd
                #:flexi-streams          ; UTF8 encode/decode
+               #:trivial-backtrace      ; logging backtraces
                )
   :in-order-to ((asdf:test-op (asdf:test-op #:rpcq-tests)))
   :pathname "src/"


### PR DESCRIPTION
Add a `:DEBUG` keyword argument to `RPCQ:START-SERVER`. If non-nil, log a backtrace when the handler throws an error.

~~Also adds a test for `UNKNOWN-METHOD-ERROR` because why not?~~
edit: The "unknown-method-error` test wound up being included in #99, so I've dropped it here.

Closes #87