### PR TITLE
Removing typing and future modules from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ msgpack == 0.6
 python-rapidjson
 pyzmq>=17
 ruamel.yaml
-typing
 
 # testing
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-future
 msgpack == 0.6
 python-rapidjson
 pyzmq>=17

--- a/rpcq/test/test_base.py
+++ b/rpcq/test/test_base.py
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-from __future__ import print_function
 import logging
 
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         'python-rapidjson',
         'pyzmq>=17',
         'ruamel.yaml',
-        'typing'
     ],
     keywords='quantum rpc qcs',
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'future',
         'msgpack>=0.6',
         'python-rapidjson',
         'pyzmq>=17',


### PR DESCRIPTION
We only support python >= 3.6, so no need for the future module. The only future import was in `test_base.py`, where we imported `print_function`, but that file never calls print anyway.

The typing module is included in the standard library since 3.5.

Fixes #97