### PR TITLE
Ensure that ERRORs are handled as well as SERIOUS-CONDITIONs

### DIFF
--- a/rpcq-tests.asd
+++ b/rpcq-tests.asd
@@ -21,6 +21,7 @@
   :depends-on (
                #:rpcq
                #:cl-messagepack
+               #:cl-syslog
                #:uiop
                #:fiasco
                )

--- a/rpcq-tests.asd
+++ b/rpcq-tests.asd
@@ -20,6 +20,7 @@
   :author "Rigetti Computing <info@rigetti.com>"
   :depends-on (
                #:rpcq
+               #:cl-messagepack
                #:uiop
                #:fiasco
                )

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -142,26 +142,31 @@
 (defun error-with-serious-condition ()
   (error 'serious-condition))
 
-(deftest test-serious-condition ()
-  (with-unique-rpc-address (addr)
-    (let* ((server-function
-             (lambda ()
-               (let ((dt (rpcq:make-dispatch-table)))
-                 (rpcq:dispatch-table-add-handler dt 'error-with-serious-condition)
-                 (rpcq:start-server :timeout 5
-                                    :dispatch-table dt
-                                    :listen-addresses (list addr)))))
-           (server-thread (bt:make-thread server-function)))
-      (sleep 1)
-      (unwind-protect
-           ;; hook up the client
-           (rpcq:with-rpc-client (client addr)
-             ;; send a communique
-             (signals rpc-error
-               (rpcq:rpc-call client "error-with-serious-condition")))
-        ;; kill the server thread
-        #+ccl
-        (loop :while (bt:thread-alive-p server-thread)
-              :do (sleep 1) (bt:destroy-thread server-thread))
-        #-ccl
-        (bt:destroy-thread server-thread)))))
+(defun error-with-error-condition ()
+  (error "owie!"))
+
+(deftest test-error-handling ()
+  (dolist (rpc-method '("error-with-serious-condition"
+                        "error-with-error-condition"
+                        "unknown-method"))
+    (with-unique-rpc-address (addr)
+      (let* ((server-function
+               (lambda ()
+                 (let ((dt (rpcq:make-dispatch-table)))
+                   (rpcq:dispatch-table-add-handler dt 'error-with-serious-condition)
+                   (rpcq:start-server :dispatch-table dt
+                                      :listen-addresses (list addr)))))
+             (server-thread (bt:make-thread server-function)))
+        (sleep 1)
+        (unwind-protect
+             ;; hook up the client
+             (rpcq:with-rpc-client (client addr)
+               ;; send a communique
+               (signals rpc-error
+                 (rpcq:rpc-call client rpc-method)))
+          ;; kill the server thread
+          #+ccl
+          (loop :while (bt:thread-alive-p server-thread)
+                :do (sleep 1) (bt:destroy-thread server-thread))
+          #-ccl
+          (bt:destroy-thread server-thread))))))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -161,100 +161,101 @@ DISPATCH-TABLE and LOGGING-STREAM are both required arguments.  TIMEOUT is of ty
        (tagbody
           :start
           (let ((warnings (make-array 0 :adjustable t :fill-pointer 0))
-                request result reply start-time)
+                request result reply start-time identity empty-frame raw-request)
             (handler-bind
                 ((warning (lambda (c) (vector-push-extend
                                        (make-instance '|RPCWarning|
                                                       :|body| (princ-to-string c)
                                                       :|kind| (princ-to-string (type-of c)))
                                        warnings))))
+              (handler-bind
+                  ((error (lambda (c)
+                            ;; we can't even reply to the client. log the error and restart the loop.
+                            (cl-syslog:format-log logger ':err "Threw generic error before RPC call:~%~a" c)
+                            (go :start))))
+                (setf (values identity empty-frame raw-request) (%pull-raw-request receiver)
+                      start-time (get-internal-real-time)
+                      request (deserialize raw-request))
+                (unless (typep request '|RPCRequest|)
+                  (error 'not-an-rpcrequest :object request)))
+
+              (cl-syslog:format-log logger ':info
+                                    "Request ~a received for ~a"
+                                    (|RPCRequest-id| request)
+                                    (|RPCRequest-method| request))
+
               (macrolet ((log-completion-message (priority control &rest args)
                            `(cl-syslog:rfc-log
-                             (logger ,priority ,control ,@args)
-                             (:msgid "LOG0002")
-                             (|rigetti@0000|
-                              |methodName| (|RPCRequest-method| request)
-                              |requestID| (|RPCRequest-id| request)
-                              |wallTime| (format nil "~f" (/ (- (get-internal-real-time) start-time)
-                                                             internal-time-units-per-second))
-                              |error| ,(if (<= (cl-syslog:get-priority priority)
-                                               (cl-syslog:get-priority ':err))
-                                           "true"
-                                           "false")))))
-                (multiple-value-bind (identity empty-frame raw-request)
-                    (handler-case (%pull-raw-request receiver)
-                      (error (c)
-                        (cl-syslog:format-log logger ':err "Threw generic error before RPC call:~%~a" c)
-                        (go :start)))
-                  (tagbody
-                     (flet ((error-processor (c h)
-                              (declare (ignore h))
-                              ;; this is where error handlers go for errors where we can reply to the client
-                              (typecase c
-                                (unknown-rpc-method
-                                 (log-completion-message :err "Request ~a error: method ~a unknown"
-                                                         (|RPCRequest-id| request)
-                                                         (|RPCRequest-method| request))
-                                 (setf reply (make-instance '|RPCError|
-                                                            :|id| (|RPCRequest-id| request)
-                                                            :|error| (format nil "Method named \"~a\" is unknown."
-                                                                             (|RPCRequest-method| request))
-                                                            :|warnings| warnings)))
-                                (bt:timeout
-                                 (log-completion-message :err "Request ~a error: timed out"
-                                                         (|RPCRequest-id| request))
-                                 (setf reply (make-instance '|RPCError|
-                                                            :|id| (|RPCRequest-id| request)
-                                                            :|error| (format nil "Execution timed out.  Note: time limit: ~a seconds." timeout)
-                                                            :|warnings| warnings)))
-                                (otherwise
-                                 (log-completion-message :err
-                                                         "Request ~a error: Unhandled error in host program:~%~a"
-                                                         (|RPCRequest-id| request)
-                                                         c)
-                                 (setf reply (make-instance '|RPCError|
-                                                            :|id| (|RPCRequest-id| request)
-                                                            :|error| (princ-to-string c)
-                                                            :|warnings| warnings))))
-                              (go :skip-to-send)))
-                       (let ((#+sbcl sb-ext:*invoke-debugger-hook*
-                              #-sbcl *debugger-hook* #'error-processor))
-                         (setf start-time (get-internal-real-time))
-                         (setf request (deserialize raw-request))
-                         (unless (typep request '|RPCRequest|)
-                           (error 'not-an-rpcrequest
-                                  :object request))
-                         (cl-syslog:format-log logger ':info
-                                               "Request ~a received for ~a"
-                                               (|RPCRequest-id| request)
-                                               (|RPCRequest-method| request))
-                         (let ((kwargs-as-plist
-                                 (loop :for key :being :the :hash-keys :of (|RPCRequest-params| request)
-                                         :using (hash-value val)
-                                       :unless (string= "*args" key)
-                                         :append (list (str->lisp-keyword key) val)))
-                               (args-as-list (gethash "*args" (|RPCRequest-params| request))))
-                           (let ((f (gethash (|RPCRequest-method| request) dispatch-table)))
-                             (unless f
-                               (error 'unknown-rpc-method
-                                      :method-name (|RPCRequest-method| request)))
-                             (setf result
-                                   (if timeout
-                                       (bt:with-timeout (timeout)
-                                         (apply f (concatenate 'list args-as-list kwargs-as-plist)))
-                                       (apply f (concatenate 'list args-as-list kwargs-as-plist))))
-                             (setf reply (make-instance '|RPCReply|
-                                                        :|id| (|RPCRequest-id| request)
-                                                        :|result| result
-                                                        :|warnings| warnings))))
-                         (log-completion-message :info "Requested ~a completed" (|RPCRequest-method| request))))
-                   :skip-to-send
-                     ;; send the client response, whether success or failure
-                     (handler-case
-                         (%push-raw-request receiver identity empty-frame (serialize reply))
-                       (error (c)
-                         (cl-syslog:format-log logger ':err
-                                               "Threw generic error after RPC call, during reply encoding:~%~a" c))))))))))))
+                                (logger ,priority ,control ,@args)
+                              (:msgid "LOG0002")
+                              (|rigetti@0000|
+                               |methodName| (|RPCRequest-method| request)
+                               |requestID| (|RPCRequest-id| request)
+                               |wallTime| (format nil "~f" (/ (- (get-internal-real-time) start-time)
+                                                              internal-time-units-per-second))
+                               |error| ,(if (<= (cl-syslog:get-priority priority)
+                                                (cl-syslog:get-priority ':err))
+                                            "true"
+                                            "false")))))
+                (tagbody
+                   (flet ((error-processor (c h)
+                            (declare (ignore h))
+                            ;; this is where error handlers go for errors where we can reply to the client
+                            (typecase c
+                              (unknown-rpc-method
+                               (log-completion-message :err "Request ~a error: method ~a unknown"
+                                                       (|RPCRequest-id| request)
+                                                       (|RPCRequest-method| request))
+                               (setf reply (make-instance '|RPCError|
+                                                          :|id| (|RPCRequest-id| request)
+                                                          :|error| (format nil "Method named \"~a\" is unknown."
+                                                                           (|RPCRequest-method| request))
+                                                          :|warnings| warnings)))
+                              (bt:timeout
+                               (log-completion-message :err "Request ~a error: timed out"
+                                                       (|RPCRequest-id| request))
+                               (setf reply (make-instance '|RPCError|
+                                                          :|id| (|RPCRequest-id| request)
+                                                          :|error| (format nil "Execution timed out.  Note: time limit: ~a seconds." timeout)
+                                                          :|warnings| warnings)))
+                              (otherwise
+                               (log-completion-message :err
+                                                       "Request ~a error: Unhandled error in host program:~%~a"
+                                                       (|RPCRequest-id| request)
+                                                       c)
+                               (setf reply (make-instance '|RPCError|
+                                                          :|id| (|RPCRequest-id| request)
+                                                          :|error| (princ-to-string c)
+                                                          :|warnings| warnings))))
+                            (go :skip-to-send)))
+                     (let ((#+sbcl sb-ext:*invoke-debugger-hook*
+                            #-sbcl *debugger-hook* #'error-processor)
+                           (kwargs-as-plist
+                             (loop :for key :being :the :hash-keys :of (|RPCRequest-params| request)
+                                     :using (hash-value val)
+                                   :unless (string= "*args" key)
+                                     :append (list (str->lisp-keyword key) val)))
+                           (args-as-list (gethash "*args" (|RPCRequest-params| request)))
+                           (f (gethash (|RPCRequest-method| request) dispatch-table)))
+                       (unless f
+                         (error 'unknown-rpc-method :method-name (|RPCRequest-method| request)))
+                       (setf result
+                             (if timeout
+                                 (bt:with-timeout (timeout)
+                                   (apply f (concatenate 'list args-as-list kwargs-as-plist)))
+                                 (apply f (concatenate 'list args-as-list kwargs-as-plist))))
+                       (setf reply (make-instance '|RPCReply|
+                                                  :|id| (|RPCRequest-id| request)
+                                                  :|result| result
+                                                  :|warnings| warnings))
+                       (log-completion-message :info "Requested ~a completed" (|RPCRequest-method| request))))
+                 :skip-to-send
+                   ;; send the client response, whether success or failure
+                   (handler-case
+                       (%push-raw-request receiver identity empty-frame (serialize reply))
+                     (error (c)
+                       (cl-syslog:format-log logger ':err
+                                             "Threw generic error after RPC call, during reply encoding:~%~a" c)))))))))))
 
 (defun start-server (&key
                        dispatch-table


### PR DESCRIPTION
The `*DEBUGGER-HOOK*` binding added in c21df22 was being preempted by the active `ERROR` handler introduced by the outermost `HANDLER-CASE` in `%RPC-SERVER-THREAD-WORKER`. As a result, any `ERROR`s signaled during the processing (as opposed to `SERIOUS-CONDITION`s) wound up in the "this is where errors go where we can't even reply to the client" handler, which only logged a message but did not send any reply. This would cause clients to hang indefinitely awaiting a response.

As a quick-fix: (1) switch the outer `HANDLER-CASE` to a `TAGBODY` form that establishes a `:START` tag at the top of the loop, (2) push the `HANDLER-CASE` scope down to only cover pre-request deser errors, and (3) `(GO :START)` in the error handler after logging the error.

Since there is no longer any active, applicable handler for `ERROR`s that occur within the scope of the `*DEBUGGER-HOOK*` binding, `INVOKE-DEBUGGER` is called on our custom `ERROR-PROCESSOR`, which handles logging and creating the `|RPCError|` response.

See also the discussion in https://github.com/rigetti/rpcq/pull/94
