### PR TITLE
Support dataclasses for Python 3.6 in client and server

### DIFF
--- a/rpcq/_client.py
+++ b/rpcq/_client.py
@@ -15,8 +15,8 @@
 ##############################################################################
 import asyncio
 import logging
+import sys
 import time
-from dataclasses import dataclass
 from typing import Dict, Optional, Union
 from warnings import warn
 
@@ -26,6 +26,11 @@ import zmq.asyncio
 from rpcq._base import to_msgpack, from_msgpack
 import rpcq._utils as utils
 from rpcq.messages import RPCError, RPCReply
+
+if sys.version_info < (3, 7):
+    from rpcq.external.dataclasses import dataclass
+else:
+    from dataclasses import dataclass
 
 _log = logging.getLogger(__name__)
 

--- a/rpcq/_server.py
+++ b/rpcq/_server.py
@@ -17,8 +17,8 @@
 Server that accepts JSON RPC requests and returns JSON RPC replies/errors.
 """
 import asyncio
-from dataclasses import dataclass
 import logging
+import sys
 from asyncio import AbstractEventLoop
 from typing import Callable, List, Optional, Tuple
 from datetime import datetime
@@ -29,6 +29,11 @@ from zmq.auth.asyncio import AsyncioAuthenticator
 from rpcq._base import to_msgpack, from_msgpack
 from rpcq._spec import RPCSpec
 from rpcq.messages import RPCRequest
+
+if sys.version_info < (3, 7):
+    from rpcq.external.dataclasses import dataclass
+else:
+    from dataclasses import dataclass
 
 _log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Dataclasses, used for _client.py::ClientAuthConfig and _server.py::ServerAuthConfig, were added in Python 3.7. Since `rpcq` is otherwise compatible with Python 3.6, this commit adds the Python 3.6 backport for `dataclasses` to maintain that compatibility.