### PR TITLE
Update quicklisp_version to 2019-11-30 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rigetti/lisp:2019-07-11
+FROM rigetti/lisp:2019-11-30
 
 # install build dependencies
 COPY Makefile /src/rpcq/Makefile


### PR DESCRIPTION
This is not required, but it seems reasonable to use the same `quicklisp_version` across the quilc, qvm, and rpcq Dockerfiles. Plus, up-to-date lieberries are good.