### PR TITLE
Fix some warnings and whatnot

### DIFF
--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -209,12 +209,10 @@
            (rpcq:with-rpc-client (client addr :timeout 1)
              (signals bt:timeout
                (rpcq::%rpc-call-raw-request client
-                                            "test-method"
                                             (princ-to-string (uuid:make-v4-uuid))
                                             ;; not a valid |RPCRequest|
                                             (make-array 8 :element-type '(unsigned-byte 8)
-                                                          :initial-element 0)
-                                            '())
+                                                          :initial-element 0))
                (is (search "Threw generic error before RPC call"
                            (get-output-stream-string log-stream)))))
         ;; kill the server thread
@@ -243,7 +241,6 @@
            (rpcq:with-rpc-client (client addr :timeout 1)
              (signals bt:timeout
                (rpcq::%rpc-call-raw-request client
-                                            "test-method"
                                             (princ-to-string (uuid:make-v4-uuid))
                                             ;; Bind MESSAGEPACK:*EXTENDED-TYPES* here, which allows
                                             ;; us to serialize the extended type. Since the bindings
@@ -253,8 +250,7 @@
                                             (let ((messagepack:*extended-types*
                                                     (messagepack:define-extension-types
                                                         '(0 deserialize-bomb))))
-                                              (rpcq::serialize (make-instance 'deserialize-bomb :id 9)))
-                                            '()))
+                                              (rpcq::serialize (make-instance 'deserialize-bomb :id 9)))))
              (is (search "Threw generic error before RPC call"
                          (get-output-stream-string log-stream))))
         ;; kill the server thread

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -244,7 +244,7 @@
                                             (princ-to-string (uuid:make-v4-uuid))
                                             ;; Bind MESSAGEPACK:*EXTENDED-TYPES* here, which allows
                                             ;; us to serialize the extended type. Since the bindings
-                                            ;; aren't in affect for the rpc server, this will result
+                                            ;; aren't in effect for the rpc server, this will result
                                             ;; in an error when messagepack attempts to deserialize
                                             ;; the unknown extended type.
                                             (let ((messagepack:*extended-types*

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -87,7 +87,7 @@
       (process-args args '())
       **kwargs)))
 
-(defun %rpc-call-raw-request (client call uuid payload args)
+(defun %rpc-call-raw-request (client uuid payload)
   "An unsafe version of RPC-CALL that does not verify that PAYLOAD is valid RPCRequest payload.
 
 Useful for testing behavior when sending an invalid RPC request.
@@ -162,7 +162,7 @@ Returns the result of the RPC method call.
                                  :|params| (prepare-rpc-call-args args)
                                  :|method| (sanitize-name call)))
          (payload (serialize request)))
-    (%rpc-call-raw-request client call uuid payload args)))
+    (%rpc-call-raw-request client uuid payload)))
 
 
 (defmacro with-rpc-client ((client endpoint &rest options) &body body)


### PR DESCRIPTION
##### Add DEFVAR for `*MOCKED-NAMESPACE*` and prefer it in `CURRENT-NAMESPACE`

Add a `DEFVAR` form for `*MOCKED-NAMESPACE*` to avoid an undefined variable warning when compiling.

Also, check `*MOCKED-NAMESPACE*` first in `CURRENT-NAMESPACE` to allow overriding the namespace even if one of `*{LOAD,COMPILE-FILE}-TRUENAME*` is defined.

##### Fix style-warning about unused args in `%RPC-CALL-RAW-REQUEST`

`CALL` and `ARGS` are not used in `%RPC-CALL-RAW-REQUEST`. These style-warnings crept as part of the refactoring in #99.