### PR TITLE
Add friendly Lisp accessors to RPCQ message objects

### DIFF
--- a/src/client.lisp
+++ b/src/client.lisp
@@ -100,11 +100,11 @@ Useful for testing behavior when sending an invalid RPC request.
 Returns the result of the RPC method call.
 "
   (let ((socket (rpc-client-socket client)))
-    (cffi:with-foreign-object (foreign-payload :uint8 (length payload))
-      (dotimes (j (length payload))
+    (cffi:with-foreign-object (foreign-payload :uint8 (cl:length payload))
+      (dotimes (j (cl:length payload))
         (setf (cffi:mem-aref foreign-payload ':uint8 j)
               (aref payload j)))
-      (pzmq:send socket foreign-payload :len (length payload)))
+      (pzmq:send socket foreign-payload :len (cl:length payload)))
     ;; NOTE: Here lies a tail-recursive loop that waits for a reply.
     ;;       Lisp users working in an implementation that doesn't handle
     ;;       tail-recursion well should beware that receiving a bunch of bad
@@ -123,9 +123,9 @@ Returns the result of the RPC method call.
                          :do (warn "Warning during RPC call: ~a: ~a"
                                    (|RPCWarning-kind| rpc-warning)
                                    (|RPCWarning-body| rpc-warning)))
-                   (error 'rpc-error
-                          :string (|RPCError-error| unpacked-reply)
-                          :id (|RPCError-id| unpacked-reply)))
+                   (cl:error 'rpc-error
+                             :string (|RPCError-error| unpacked-reply)
+                             :id (|RPCError-id| unpacked-reply)))
                   (t
                    (warn "Discarding RPC error with ID ~a, which doesn't match ours of ~a."
                          (|RPCError-id| unpacked-reply) uuid)
@@ -143,9 +143,9 @@ Returns the result of the RPC method call.
                          (|RPCReply-id| unpacked-reply) uuid)
                    (loop-til-reply))))
                (otherwise
-                (error 'rpc-protocol-error
-                       :id uuid
-                       :object unpacked-reply))))))
+                (cl:error 'rpc-protocol-error
+                          :id uuid
+                          :object unpacked-reply))))))
       (cond
         ((rpc-client-timeout client)
          (let ((timeout (rpc-client-timeout client)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -40,4 +40,5 @@
            #:rpc-protocol-error
            #:rpc-protocol-error-id
            #:rpc-protocol-error-object
-           ))
+           )
+  (:shadow #:phase #:stream #:time #:type #:length #:method #:error #:sequence))


### PR DESCRIPTION
RPCQ messages are quite convenient to work with from Python, but somewhat awkward from Lisp. This PR proposes a change to `defmessage`, namely that message slots get a second, somewhat more idiomatic, accessor. 

The convention adopted here is simply that the slot name, which is in `|some_thing|`, yield an accessor `some-thing`. Note that I do not prefix with the class name. There are some messages (e.g. waveforms, schedule ir instructions), where having an honest generic is convenient, rather than having several similar accessors (e.g. `gaussianwaveform-t0`, `draggaussianwaveform-t0`, `hermitegaussianwaveform-t0`). I also prefer to have the accessors generated systematically from the slot name, as opposed to augmenting `defmessage` slot specs with an additional argument indicating the alternative accessor.

The unfortunate consequence of this convention is that it clutters the actual RPCQ code a bit, in that some accessor names collide with CL symbols (e.g. an `|error|` slot generates an `error` accessor). I am open to alternative suggestions that are in line with the basic goal, namely to make Lisp code which manipulates RPCQ messages pleasant for a human to read and write.