### PR TITLE
add friendly lisp accessors on RPCQ messages

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -22,6 +22,7 @@
   :depends-on (#:alexandria             ; Utilities
                #:parse-float            ; Float parsing
                #:yason                  ; JSON generation
+               #:cl-ppcre               ; Name mangling
                ;; RPC requirements
                #:pzmq                   ; communication layer
                #:cl-messagepack         ; message packer

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -272,35 +272,6 @@ We distinguish between the following options for any field type:
                plist)
     tbl))
 
-
-(defun snake-to-kebab (string)
-  "Convert STRING from snake_case to KEBAB-CASE. Yum!"
-  (string-upcase (substitute #\- #\_ string)))
-
-(defun camel-to-kebab (string)
-  "Convert STRING from CamelCase to KEBAB-CASE. Yum!"
-  (let ((raw-segments (cl-ppcre:all-matches-as-strings "(^[a-z]|[A-Z0-9])[a-z]*"
-                                                       string))
-        (running-singletons nil)
-        (kebab-segments nil))
-    (loop :for seg :in raw-segments
-          :if (= 1 (length seg))
-            :do (push seg running-singletons)
-          :else
-            :do (progn
-                  (when running-singletons
-                    (push (apply #'concatenate 'string
-                                 (nreverse running-singletons))
-                          kebab-segments)
-                    (setf running-singletons nil))
-                  (push seg kebab-segments))
-          :finally (when running-singletons
-                     (push (apply #'concatenate 'string
-                                  (nreverse running-singletons))
-                           kebab-segments)))
-
-    (format nil "~{~:@(~A~)~^-~}" (nreverse kebab-segments))))
-
 (defmacro defmessage (class-name parent-name field-specs &key (documentation nil))
   "Create a (de-)serializable message definition.
 


### PR DESCRIPTION
RPCQ messages are quite convenient to work with in Python, but Lisp code manipulating these is neither friendly to write nor friendly to read, primarily due to the use of `|CamelCase_snake_case|` accessors. This PR adds extra, friendlier accessors for Lisp users. This does not otherwise impact the behavior of RPCQ.

The convention adopted is that the new slot accessors are of the form `<kebab-style-class-name>-<kebab-style-slot-name>`, where these mangled names are taken to be reasonably Lispy.

Example:
```
RPCQ> (let ((channel (make-instance '|AWGChannel| :|sample_rate| 2d-9 :|direction| "tx")))
        (format t "Rate: ~A~%Delay: ~A"
                (awg-channel-sample-rate channel)
                (awg-channel-delay channel)))
Rate: 2.0d-9
Delay: 0.0d0
```

It occurred to me that for some of the RPCQ message slots, it might be convenient to have generic accessors (e.g. _every_ `|Instruction|` has a `|time|` slot, hence we could have an `instruction-time` defined on all messages which inherit from the `|Instruction|` class). However, to keep things simple I have decided to not fuss about this. For my own uses (e.g. in `cl-quil`), I am happy to introduce the handful of generics as need be.