### PR TITLE
Coerce *args to a VECTOR in PREPARE-RPC-CALL-ARGS

### DIFF
--- a/src-tests/suite.lisp
+++ b/src-tests/suite.lisp
@@ -71,10 +71,10 @@
 (deftest test-prepare-rpc-call-args ()
   (loop
     :with testcases :=
-    '((() . ("*args" ()))
-      ((1 2 3 "four") . ("*args" (1 2 3 "four")))
-      ((:only-kw 23 :allowed t) . ("*args" () "only_kw" 23 "allowed" t))
-      (("a1" 42 3.0 :kw1 "k1" :kw-2 "k2") . ("*args" ("a1" 42 3.0) "kw1" "k1" "kw_2" "k2")))
+    '((() . ("*args" #()))
+      ((1 2 3 "four") . ("*args" #(1 2 3 "four")))
+      ((:only-kw 23 :allowed t) . ("*args" #() "only_kw" 23 "allowed" t))
+      (("a1" 42 3.0 :kw1 "k1" :kw-2 "k2") . ("*args" #("a1" 42 3.0) "kw1" "k1" "kw_2" "k2")))
     :for (args . expected-plist) :in testcases :do
       (is (equalp (rpcq::prepare-rpc-call-args args)
                   (alexandria:plist-hash-table expected-plist :test 'equal)))))

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -70,7 +70,7 @@
         ((process-args (args *args)
            (cond
              ((or (null args) (keywordp (first args)))
-              (setf (gethash "*args" **kwargs) (reverse *args))
+              (setf (gethash "*args" **kwargs) (coerce (reverse *args) 'vector))
               (process-**kwargs args))
              (t
               (process-args (rest args) (cons (first args) *args)))))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -206,7 +206,7 @@ These warnings are included in the RPC response that is returned to the caller.
                     :using (hash-value val)
                   :unless (string= "*args" key)
                     :append (list (str->lisp-keyword key) val)))
-          (args-as-list (gethash "*args" (|RPCRequest-params| request)))
+          (positional-args (gethash "*args" (|RPCRequest-params| request)))
           (f (gethash (|RPCRequest-method| request) dispatch-table)))
       (unless f
         (error 'unknown-rpc-method :method-name (|RPCRequest-method| request)))
@@ -216,7 +216,7 @@ These warnings are included in the RPC response that is returned to the caller.
                              (when debug
                                (finish-output *error-output*)
                                (trivial-backtrace:print-backtrace c :output *error-output*)))))
-                 (apply f (concatenate 'list args-as-list kwargs-as-plist)))))
+                 (apply f (concatenate 'list positional-args kwargs-as-plist)))))
         (let ((result (if timeout
                           (bt:with-timeout (timeout)
                             (apply-handler))


### PR DESCRIPTION
Coerce positional args to a `VECTOR` in `PREPARE-RPC-CALL-ARGS` to ensure they are encoded as an array. This makes no difference when positional args exist since both non-empty `LIST`s and `ARRAY`s get encoded to messagepack array formats; if args is `NIL`, however, `CL-MESSAGEPACK` encodes `NIL` to a messagepack NIL format `0xc0`, which gets decoded as `None` on the Python side. This results in an `Exception` being raised in `RPCSpec.run_handler` when attempting to decode the args since it expects `*args` to be an `Iterable`, not `None`.

The RPCQ lisp server was unaffected by this since messagepack NIL is decode to lisp `NIL`, and the lisp server only calls generic `SEQUENCE` processing functions (`CONCATENATE`) on the deserialized value, and hence doesn't distinguish between an empty `LIST` or `ARRAY`.