### PR TITLE
KILL-THREAD-SLOWLY

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
 test-python:
   stage: test
   tags:
-    - github
+    - ec2-github
   only:
     refs:
       - branches
@@ -21,7 +21,7 @@ test-python:
 test-lisp:
   stage: test
   tags:
-    - github
+    - ec2-github
   only:
     refs:
       - branches


### PR DESCRIPTION
Add a `(SLEEP 1)` after every `BT:DESTROY-THREAD` call.

This is a work-around that enables switching over to EC2 runners for the gitlab CI. Something about the EC2 environment was tickling a race in our combination of using `BT:DESTROY-THREAD` + our reliance on `PZMQ`'s implicit global `*DEFAULT-CONTEXT*`.

A proper fix for this likely entails some combination of

1) Explicitly creating our own `PZMQ:CONTEXT` in `RPCQ:START-SERVER` and passing that down to worker threads.

2) Adding a graceful shutdown option to the `RPCQ` server to avoid the need to `BT:DESTROY-THREAD` (see #75).