### PR TITLE
Switch gitlab ci tag back from ec2-github to github

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
 test-python:
   stage: test
   tags:
-    - ec2-github
+    - github
   only:
     refs:
       - branches
@@ -21,7 +21,7 @@ test-python:
 test-lisp:
   stage: test
   tags:
-    - ec2-github
+    - github
   only:
     refs:
       - branches


### PR DESCRIPTION
According to jmackey, this change from #113 was only needed for testing and should be reverted.