### PR TITLE
Add FROM-YAML-FILE

### DIFF
--- a/rpcq.asd
+++ b/rpcq.asd
@@ -23,6 +23,7 @@
                #:parse-float            ; Float parsing
                #:yason                  ; JSON generation
                #:cl-ppcre               ; Name mangling
+               #:cl-yaml                ; YAML read/write
                ;; RPC requirements
                #:pzmq                   ; communication layer
                #:cl-messagepack         ; message packer

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -164,6 +164,12 @@ The input strings are assumed to be FORMAT-compatible, so sequences like ~<newli
       (stream
        (%deserialize (messagepack:decode-stream payload))))))
 
+(defun from-yaml-file (filespec)
+  "Read a RPCQ object from the yaml file designated by FILESPEC."
+  (%deserialize
+   (yaml:parse
+    (alexandria:read-file-into-string filespec))))
+
 (defun slot-type-and-initform (field-type required default)
   "Translate a FIELD-TYPE to a Lisp type and initform taking into account
 whether the field is REQUIRED and a specified DEFAULT value.


### PR DESCRIPTION
This is just a Lisp-y version of an old favorite, `rpcq.base._from_yaml_file` (https://github.com/rigetti/rpcq/blob/master/rpcq/_base.py#L203). My reason for adding this is just that the "standard" specification of a `DeployedRack` is via its yaml form. 

I do not otherwise support or condone yaml.