### PR TITLE
Restrict msgpack dependency to <1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-msgpack == 0.6
+msgpack >=0.6,<1.0
 python-rapidjson
 pyzmq>=17
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# If you change the requirements here, don't forget to make the
+# corresponding change in the conda-forge rcpq-feedstock here:
+#
+# https://github.com/conda-forge/rpcq-feedstock/blob/master/recipe/meta.yaml
+
 msgpack >=0.6,<1.0
 python-rapidjson
 pyzmq>=17

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@
 #
 # https://github.com/conda-forge/rpcq-feedstock/blob/master/recipe/meta.yaml
 
+# msgpack 1.0 introduced breaking changes. See
+# https://github.com/rigetti/rpcq/issues/118
 msgpack >=0.6,<1.0
 python-rapidjson
 pyzmq>=17

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'msgpack>=0.6',
+        'msgpack>=0.6,<1.0',
         'python-rapidjson',
         'pyzmq>=17',
         'ruamel.yaml',


### PR DESCRIPTION
The msgpack 1.0 release includes some changes that break deserialization of certain `RewriteArithmeticResponse` calls from pyquil. Restrict the version to <1.0 for now until we are ready to test and fix an upgrade to 1.0.

Also, add a reminder to requirements.txt about updating the rpcq-feedstock.

Updates #118

See also:

rigetti/pyquil#1178