### PR TITLE
RPCError messages should use `repr`, not `str`

### DIFF
--- a/rpcq/_server.py
+++ b/rpcq/_server.py
@@ -182,7 +182,7 @@ class Server:
                 except Exception as e:
                     if self.serialize_exceptions:
                         _log.exception('Exception thrown in Server run loop during request '
-                                       'reception: {}'.format(str(e)))
+                                       'reception: {}'.format(repr(e)))
                     else:
                         raise e
                 finally:
@@ -196,7 +196,7 @@ class Server:
                 except Exception as e:
                     if self.serialize_exceptions:
                         _log.exception('Exception thrown in Server run loop during request '
-                                       'dispatch: {}'.format(str(e)))
+                                       'dispatch: {}'.format(repr(e)))
                     else:
                         raise e
 

--- a/rpcq/_spec.py
+++ b/rpcq/_spec.py
@@ -110,7 +110,7 @@ class RPCSpec(object):
             try:
                 rpc_handler = self.get_handler(request)
             except RPCMethodError as e:
-                return rpc_error(request.id, str(e), warnings=warnings)
+                return rpc_error(request.id, repr(e), warnings=warnings)
 
             try:
                 # Run RPC and get result
@@ -125,10 +125,10 @@ class RPCSpec(object):
                     _traceback = traceback.format_exc()
                     _log.error(_traceback)
                     if self.provide_tracebacks:
-                        return rpc_error(request.id, "{}\n{}".format(str(e), _traceback),
+                        return rpc_error(request.id, "{}\n{}".format(repr(e), _traceback),
                                          warnings=warnings)
                     else:
-                        return rpc_error(request.id, str(e), warnings=warnings)
+                        return rpc_error(request.id, repr(e), warnings=warnings)
                 else:
                     raise e
 

--- a/rpcq/test/test_auth.py
+++ b/rpcq/test/test_auth.py
@@ -162,6 +162,9 @@ def client_auth(request, m_endpoints):
     return client
 
 
+OOPS_VALUE_ERROR_STR = "ValueError('Oops.',)\nTraceback (most recent call last):\n  "
+
+
 def test_client_warning(server, client_auth):
     with catch_warnings(record=True) as warnings:
         result = client_auth.call('just_a_warning')
@@ -180,7 +183,7 @@ def test_client_simple(server, client_auth):
     except RPCError as e:
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
 
@@ -218,7 +221,7 @@ async def test_async_client_rpcerrorerror(server, client_auth):
     except RPCErrorError as e:  # RPCErrorError is deprecated
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
     assert reply == "bar"
@@ -234,7 +237,7 @@ async def test_async_client(server, client_auth):
     except RPCError as e:
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
     assert reply == "bar"

--- a/rpcq/test/test_rpc.py
+++ b/rpcq/test/test_rpc.py
@@ -115,6 +115,9 @@ def client(request, m_endpoints):
     return client
 
 
+OOPS_VALUE_ERROR_STR = "ValueError('Oops.',)\nTraceback (most recent call last):\n  "
+
+
 def test_client_rpcerrorerror(server, client):
     assert client.call('add', 1, 1) == 2
     assert client.call('foo') == 'bar'
@@ -125,7 +128,7 @@ def test_client_rpcerrorerror(server, client):
     except RPCErrorError as e:  # RPCErrorError is deprecated
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
 
@@ -147,7 +150,7 @@ def test_client(server, client):
     except RPCError as e:
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
 
@@ -185,7 +188,7 @@ async def test_async_client_rpcerrorerror(server, client):
     except RPCErrorError as e:  # RPCErrorError is deprecated
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
     assert reply == "bar"
@@ -201,7 +204,7 @@ async def test_async_client(server, client):
     except RPCError as e:
         # Get the full traceback and make sure it gets propagated correctly. Remove line numbers.
         full_traceback = ''.join([i for i in str(e) if not i.isdigit()])
-        assert 'Oops.\nTraceback (most recent call last):\n  ' in full_traceback
+        assert OOPS_VALUE_ERROR_STR in full_traceback
         assert 'ValueError: Oops.' in full_traceback
 
     assert reply == "bar"


### PR DESCRIPTION
Using `str` often provides less information than`repr`.