### PR TITLE
ZMQ Curve Auth for lisp

### DIFF
--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -295,7 +295,6 @@
                  (rpcq:dispatch-table-add-handler dt 'test-method)
                  (rpcq:start-server :dispatch-table dt
                                     :auth-config (rpcq:make-server-auth-config
-                                                  :server-public-key *server-public-key-z85*
                                                   :server-secret-key *server-secret-key-z85*)
                                     :listen-addresses (list addr)))))
            (server-thread (bt:make-thread server-function)))
@@ -323,7 +322,6 @@
                  (rpcq:dispatch-table-add-handler dt 'test-method)
                  (rpcq:start-server :dispatch-table dt
                                     :auth-config (rpcq:make-server-auth-config
-                                                  :server-public-key *server-public-key-z85*
                                                   :server-secret-key *server-secret-key-z85*)
                                     :listen-addresses (list addr)))))
            (server-thread (bt:make-thread server-function)))

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -282,7 +282,7 @@
 (defun random-in-range (low high)
   "Return a random number in the range [low, high)."
   (assert (< low high))
-  (+ low (random (abs (- high low)))))
+  (+ low (random (- high low))))
 
 (deftest test-client-server-dialogue-with-curve-auth ()
   ;; Curve-enabled sockets require TCP transport. We could bind on wildcard port, but that would

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -33,9 +33,9 @@
 
 (defstruct client-auth-config
   "Holds the ZeroMQ Curve configuration for a client socket."
-  (client-secret-key nil :type (or null string))
-  (client-public-key nil :type (or null string))
-  (server-public-key nil :type (or null string)))
+  (client-secret-key (error "Must provide CLIENT-SECRET-KEY") :type string :read-only t)
+  (client-public-key (error "Must provide CLIENT-PUBLIC-KEY") :type string :read-only t)
+  (server-public-key (error "Must provide SERVER-PUBLIC-KEY") :type string :read-only t))
 
 (defstruct rpc-client
   "Holds the data for an (active) RPCQ client connection."

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -32,7 +32,6 @@
            #:client-auth-config-client-secret-key
            #:make-client-auth-config
            #:server-auth-config
-           #:server-auth-config-server-public-key
            #:server-auth-config-server-secret-key
            #:make-server-auth-config
            ;; RPC client/server functions

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -25,6 +25,16 @@
            #:from-json
            #:to-json
            #:to-json-string
+           ;; ZMQ Curve client/server auth
+           #:client-auth-config
+           #:client-auth-config-server-public-key
+           #:client-auth-config-client-public-key
+           #:client-auth-config-client-secret-key
+           #:make-client-auth-config
+           #:server-auth-config
+           #:server-auth-config-server-public-key
+           #:server-auth-config-server-secret-key
+           #:make-server-auth-config
            ;; RPC client/server functions
            #:make-dispatch-table
            #:dispatch-table-add-handler

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -49,8 +49,7 @@
 
 (defstruct server-auth-config
   "Holds the ZeroMQ Curve configuration for a server socket."
-  (server-secret-key nil :type (or null string))
-  (server-public-key nil :type (or null string)))
+  (server-secret-key (error "Must provide SERVER-SECRET-KEY") :type string :read-only t))
 
 (deftype dispatch-table ()
   'hash-table)

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -299,7 +299,7 @@ Argument descriptions:
   (let ((pool-address (format nil "inproc://~a" (uuid:make-v4-uuid))))
     (cl-syslog:format-log logger ':info
                           "Spawning server at ~a .~%" listen-addresses)
-    (pzmq:with-sockets ((clients :router :monitor) (workers :dealer :monitor))
+    (pzmq:with-sockets ((clients :router) (workers :dealer))
       (dolist (address listen-addresses)
         (pzmq:bind clients address))
       (pzmq:bind workers pool-address)


### PR DESCRIPTION
Add support for ZeroMQ Curve Auth to lisp client and server

This commit adds two new structures -- `CLIENT-AUTH-CONFIG` and `SERVER-AUTH-CONFIG` -- that store the client/server authentication keys required for configuring ZeroMQ curve auth on a socket.

In addition, both the `RPCQ:WITH-RPC-CLIENT` macro and `RPCQ:START-SERVER` function get an additional `:AUTH-CONFIG` keyword argument allowing the caller to pass in a `{CLIENT,SERVER}-AUTH-CONFIG`, respectively.

When the `:AUTH-CONFIG` option is provided, the client / server will set the appropriate ZMQ socket options to enable curve encryption (and in the case of the client socket, server authentication) for the socket.

This commit *does not* implement server-side authentication of clients. Unlike the python pyzmq package, the lisp library we use, PZMQ, does not come with any built-in authenticator, so if we ever need that functionality, we'll either have to add it to PZMQ or else implement one ourselves on top of the ZeroMQ Authentication Protocol (ZAP).

Closes #111