### PR TITLE
Fix tests on Python 3.7+ due to change in BaseException.__repr__

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ include:
 variables:
   IMAGE: rigetti/rpcq
 
-test-python:
+test-python-36:
   stage: test
   tags:
     - github
@@ -13,6 +13,32 @@ test-python:
     refs:
       - branches
   image: python:3.6
+  script:
+    - python --version
+    - pip install -r requirements.txt
+    - pytest
+
+test-python-37:
+  stage: test
+  tags:
+    - github
+  only:
+    refs:
+      - branches
+  image: python:3.7
+  script:
+    - python --version
+    - pip install -r requirements.txt
+    - pytest
+
+test-python-38:
+  stage: test
+  tags:
+    - github
+  only:
+    refs:
+      - branches
+  image: python:3.8
   script:
     - python --version
     - pip install -r requirements.txt

--- a/rpcq/test/test_auth.py
+++ b/rpcq/test/test_auth.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import os
 import signal
+import sys
 import time
 from multiprocessing import Process
 from warnings import warn, catch_warnings
@@ -161,8 +162,11 @@ def client_auth(request, m_endpoints):
     request.addfinalizer(client.close)
     return client
 
-
-OOPS_VALUE_ERROR_STR = "ValueError('Oops.',)\nTraceback (most recent call last):\n  "
+if sys.version_info < (3, 7):
+    OOPS_VALUE_ERROR_STR = "ValueError('Oops.',)\nTraceback (most recent call last):\n  "
+else:
+    # The default repr for BaseException was changed in 3.7 to elide the trailing comma.
+    OOPS_VALUE_ERROR_STR = "ValueError('Oops.')\nTraceback (most recent call last):\n  "
 
 
 def test_client_warning(server, client_auth):

--- a/rpcq/test/test_rpc.py
+++ b/rpcq/test/test_rpc.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import os
 import signal
+import sys
 import time
 from multiprocessing import Process
 from warnings import warn, catch_warnings
@@ -114,9 +115,11 @@ def client(request, m_endpoints):
     request.addfinalizer(client.close)
     return client
 
-
-OOPS_VALUE_ERROR_STR = "ValueError('Oops.',)\nTraceback (most recent call last):\n  "
-
+if sys.version_info < (3, 7):
+    OOPS_VALUE_ERROR_STR = "ValueError('Oops.',)\nTraceback (most recent call last):\n  "
+else:
+    # The default repr for BaseException was changed in 3.7 to elide the trailing comma.
+    OOPS_VALUE_ERROR_STR = "ValueError('Oops.')\nTraceback (most recent call last):\n  "
 
 def test_client_rpcerrorerror(server, client):
     assert client.call('add', 1, 1) == 2


### PR DESCRIPTION
In #120 we switched from `str` to `repr` for printing exceptions, which broke the python tests on 3.7+ due a change in python's default `BaseException.__repr__`, which dropped the trailing comma.

https://docs.python.org/3/whatsnew/3.7.html#changes-in-the-python-api

This PR also updates `.gitlab-ci.yaml` to run the pytests on all supported Python versions (3.6, 3.7, and 3.8)