### PR TITLE
Pass client timeout to server, optionally override server's timeout

### DIFF
--- a/rpcq/_client.py
+++ b/rpcq/_client.py
@@ -162,14 +162,20 @@ class Client:
         :param float rpc_timeout: Timeout in seconds for Server response, set to None to disable the timeout
         :param kwargs: Keyword args that will be passed to the remote function
         """
-        request = utils.rpc_request(method_name, *args, **kwargs)
-        _log.debug("Sending request: %s", request)
-
-        self._socket.send_multipart([to_msgpack(request)])
-
         # if an rpc_timeout override is not specified, use the one set in the Client attributes
         if rpc_timeout is None:
             rpc_timeout = self.rpc_timeout
+
+        request = utils.rpc_request(method_name, *args, **kwargs)
+        # Rather than change the utils.rpc_request interface in a
+        # non-BC way, install the timeout here. This timeout is
+        # communicated to the server, so that the server can terminate
+        # (if it so chooses) requests that will not be received by the
+        # client.
+        request.client_timeout = rpc_timeout
+        _log.debug("Sending request: %s", request)
+
+        self._socket.send_multipart([to_msgpack(request)])
 
         start_time = time.time()
         while True:

--- a/rpcq/messages.py
+++ b/rpcq/messages.py
@@ -73,6 +73,9 @@ class RPCRequest(Message):
     jsonrpc: str = "2.0"
     """The JSONRPC version."""
 
+    client_timeout: Optional[float] = None
+    """The client-side timeout for the request. The server itself may be configured with a timeout that is greater than the client-side timeout, in which case the server can choose to terminate any processing of the request."""
+
     client_key: Optional[str] = None
     """The ZeroMQ CURVE public key used to make the request, as received by the server. Empty if no key is used."""
 

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -103,7 +103,7 @@
 
 (deftest test-RPCRequest-client_timeout-overrides-server-timeout ()
   ;; If the client provides a timeout, it should override the server
-  ;; timeout, and the server should then kills jobs that exceed this
+  ;; timeout, and the server should then kill jobs that exceed this
   ;; timeout. To test this, make a request with a client timeout of 2,
   ;; the request job sleeps for 4 seconds and then raises an error. If
   ;; the server correctly kills the job, the error should not be

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -102,26 +102,32 @@
         (kill-thread-slowly server-thread)))))
 
 (deftest test-RPCRequest-client_timeout-overrides-server-timeout ()
+  ;; If the client provides a timeout, it should override the server
+  ;; timeout, and the server should then kills jobs that exceed this
+  ;; timeout. To test this, make a request with a client timeout of 2,
+  ;; the request job sleeps for 4 seconds and then raises an error. If
+  ;; the server correctly kills the job, the error should not be
+  ;; raised.
   (with-unique-rpc-address (addr)
     (let* ((server-function
              (lambda ()
                (let ((dt (rpcq:make-dispatch-table)))
-                 (rpcq:dispatch-table-add-handler dt (lambda () (sleep 2)) :name "test_method")
+                 (rpcq:dispatch-table-add-handler
+                  dt
+                  (lambda ()
+                    (sleep 4)
+                    ;; Shouldn't hit this if the client timeout was
+                    ;; respected.
+                    (error "oof"))
+                  :name "test-method")
                  (rpcq:start-server :dispatch-table dt
                                     :listen-addresses (list addr)))))
            (server-thread (bt:make-thread server-function)))
       (sleep 1)
       (unwind-protect
-           (let* ((id (format nil "~A" (uuid:make-v4-uuid)))
-                  (request (make-instance 'rpcq::|RPCRequest|
-                                          :|method| "test_method" :|params| (make-hash-table)
-                                          :|id| id :|client_timeout| 1)))
-             (rpcq:with-rpc-client (client addr)
-               (signals rpc-error
-                 (rpcq::%rpc-call-raw-request
-                  client
-                  id
-                  (rpcq:serialize request)))))
+           (rpcq:with-rpc-client (client addr :timeout 2)
+             (signals bt:timeout
+               (rpc-call client "test-method")))
         ;; kill the server thread
         (kill-thread-slowly server-thread)))))
 

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -165,6 +165,7 @@ Returns the result of the RPC method call.
   (let* ((uuid (format nil "~a" (uuid:make-v4-uuid)))
          (request (make-instance '|RPCRequest|
                                  :|id| uuid
+                                 :|client_timeout| (rpc-client-timeout client)
                                  :|params| (prepare-rpc-call-args args)
                                  :|method| (sanitize-name call)))
          (payload (serialize request)))

--- a/src/messages.lisp
+++ b/src/messages.lisp
@@ -85,7 +85,13 @@
       :type :string
       :required t)
 
-    (|client_key|
+     (|client_timeout|
+      :documentation "The client-side timeout for the request. The server itself may be configured with a timeout that is greater than the client-side timeout, in which case the server can choose to terminate any processing of the request."
+      :type :float
+      :required nil
+      :default nil)
+
+     (|client_key|
       :documentation "The ZeroMQ CURVE public key used to make the request, as received by the server. Empty if no key is used."
       :type :string
       :required nil))


### PR DESCRIPTION
If the server's timeout is shorter than the client's, keep it. If the
client's is shorter than the server's, use that timeout for the
server. This prevents the server running jobs for which the client
will not receive the results because it has already timed-out.

- [x] Test