### PR TITLE
Add SetScale instruction

### DIFF
--- a/rpcq/core_messages.py
+++ b/rpcq/core_messages.py
@@ -347,7 +347,7 @@ class Pulse(Instruction):
     waveform: str
     """The waveform label"""
 
-    scale: float = 1.e+0
+    scale: Optional[float] = 1.e+0
     """Dimensionless (re-)scaling factor which is applied to
           the envelope."""
 
@@ -385,7 +385,7 @@ class FlatPulse(Instruction):
     """Detuning [Hz] with which the pulse envelope should be
           modulated relative to the frame frequency."""
 
-    scale: float = 1.e+0
+    scale: Optional[float] = 1.e+0
     """Dimensionless (re-)scaling factor which is applied to
           the envelope."""
 

--- a/rpcq/core_messages.py
+++ b/rpcq/core_messages.py
@@ -464,6 +464,19 @@ class ShiftFrequency(Instruction):
 
 
 @dataclass(eq=False, repr=False)
+class SetScale(Instruction):
+    """
+    Set the scale of a tx-frame to a value at a specific time.
+    """
+
+    frame: str
+    """The frame label for which to set the scale."""
+
+    scale: float = 1.e+0
+    """Scale (unitless) to apply to waveforms generated on the frame."""
+
+
+@dataclass(eq=False, repr=False)
 class Capture(Instruction):
     """
     Specify an acquisition on an rx-frame as well as the

--- a/src/core-messages.lisp
+++ b/src/core-messages.lisp
@@ -566,6 +566,21 @@
   :documentation "Shift the frequency of a tx-frame by a specific amount at a\
       specific time.")
 
+(defmessage |SetScale| (|Instruction|)
+  (
+   (|frame|
+    :documentation "The frame label for which to set the scale."
+    :type :string
+    :required t)
+
+   (|scale|
+    :documentation "Scale (unitless) to apply to waveforms generated on the frame."
+    :type :float
+    :required t
+    :default 1.0))
+
+  :documentation "Set the scale of a tx-frame to a value at a specific time.")
+
 (defmessage |Capture| (|Instruction|)
     (
      (|frame|

--- a/src/core-messages.lisp
+++ b/src/core-messages.lisp
@@ -422,7 +422,7 @@
       :documentation "Dimensionless (re-)scaling factor which is applied to\
           the envelope."
       :type :float
-      :required t
+      :required nil
       :default 1.0)
 
      (|phase|
@@ -478,7 +478,7 @@
       :documentation "Dimensionless (re-)scaling factor which is applied to\
           the envelope."
       :type :float
-      :required t
+      :required nil
       :default 1.0))
 
   :documentation "Instruction to play a pulse with a constant amplitude\


### PR DESCRIPTION
Although RPCQ `Pulse` messages have a `scale` field, it is at times convenient to apply a scale factor independent of any specific pulse. To support this I have made two changes:
- addition of a `SetScale` instruction
- marking of `scale` on `Pulse` and `FlatPulse` as optional.

The intended semantics of this is that if a pulse operation has no indicated scale, the most recently applied scale factor is used. Otherwise, there are no changes to behavior. For example,
```
SetScale(frame=f, scale=x)
Pulse(..., frame=f, scale=None)
```
is equivalent to
```
Pulse(..., frame=f, scale=x)
```
whereas
```
SetScale(..., frame=f, scale=x)
Pulse(..., frame=f, scale=y)
```
is equivalent to
```
Pulse(...,frame=f, scale=y)
```
Also, all frames start with a default scaling factor of `1.0`.