### PR TITLE
Allow default None for optional bools

### DIFF
--- a/src-tests/suite.lisp
+++ b/src-tests/suite.lisp
@@ -50,14 +50,22 @@
         :required t
         :default "a string"
         :documentation "String docs.")
-
        (flt
         :type :float
         :required t
         :default 0.0
-        :documentation "A float."))
-
-
+        :documentation "A float.")
+       (optional-bool-none
+        :type :bool
+        :required nil)
+       (optional-bool-false
+        :type :bool
+        :required nil
+        :default nil)
+       (optional-bool-true
+        :type :bool
+        :required nil
+        :default t))
     :documentation "Test message")
 
   (let ((m (make-instance 'my-msg :required-int 5)))
@@ -66,7 +74,13 @@
     (is (string= (gethash "yo" (my-msg-optional-map m)) "working"))
     (is (= (length (gethash "suite" rpcq::*messages*)) 1))
     (is (typep (my-msg-flt m) 'double-float))
-    (is (string= (my-msg-str m) "a string"))))
+    (is (string= (my-msg-str m) "a string"))
+    (is (typep (my-msg-optional-bool-none m) 'optional-bool))
+    (is (eql (my-msg-optional-bool-none m) ':none))
+    (is (typep (my-msg-optional-bool-true m) 'optional-bool))
+    (is (my-msg-optional-bool-true m))
+    (is (typep (my-msg-optional-bool-false m) 'optional-bool))
+    (is (null (my-msg-optional-bool-false m)))))
 
 (deftest test-prepare-rpc-call-args ()
   (loop

--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -261,7 +261,7 @@
                                             (let ((messagepack:*extended-types*
                                                     (messagepack:define-extension-types
                                                         '(0 deserialize-bomb))))
-                                              (rpcq::serialize (make-instance 'deserialize-bomb :id 9)))))
+                                              (rpcq::serialize (make-instance 'deserialize-bomb 'messagepack-sym:id 9)))))
              (is (search "Threw generic error before RPC call"
                          (get-output-stream-string log-stream))))
         ;; kill the server thread

--- a/src/core-messages.lisp
+++ b/src/core-messages.lisp
@@ -898,8 +898,7 @@
           True  - Relay closed, allows flux current to flow.\
           False - Relay open, no flux current can flow."
       :type :bool
-      :required nil
-      :default nil))
+      :required nil))
 
   :documentation "Configuration for a single QFD Channel.")
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -52,4 +52,5 @@
            #:rpc-protocol-error
            #:rpc-protocol-error-id
            #:rpc-protocol-error-object
+           #:optional-bool
            ))


### PR DESCRIPTION
Slots of type `:bool` now support a default of `None` in the Python messages. Specifically, when a slot has both `:type :bool` and `:required nil`, *and does not have an explicit* `:default` the resulting Python message will look something like `slot: Optional[bool] = None`. This allows when to differentiate between whether a false-y value was provided (`False`) or no value was provided `None`.

Todo
- [x] Test