### PR TITLE
Update: add YokogawaGS200Channel message

### DIFF
--- a/rpcq/core_messages.py
+++ b/rpcq/core_messages.py
@@ -832,6 +832,13 @@ class QDOFastFluxChannel(Message):
 
 
 @dataclass(eq=False, repr=False)
+class YokogawaGS200Channel(Message):
+    """
+    Configuration for a single Yokogawa GS200 Channel.
+    """
+
+
+@dataclass(eq=False, repr=False)
 class LegacyUSRPSequencer(Message):
     """
     Configuration for a Legacy USRP Sequencer

--- a/src/core-messages.lisp
+++ b/src/core-messages.lisp
@@ -1071,6 +1071,11 @@
 
   :documentation "Configuration for a single QDO Fast Flux Channel.")
 
+(defmessage |YokogawaGS200Channel| ()
+    ()
+
+  :documentation "Configuration for a single Yokogawa GS200 Channel.")
+
 (defmessage |LegacyUSRPSequencer| ()
     (
      (|tx_channel|


### PR DESCRIPTION
This channel has no keys, but it is necessary to prevent ambiguity in parsing a Yokogawa's instrument settings.