### PR TITLE
Fix optional message types

### DIFF
--- a/rpcq/core_messages.py
+++ b/rpcq/core_messages.py
@@ -132,7 +132,7 @@ class HermiteGaussianWaveform(TemplateWaveform):
     fwhm: Optional[float] = None
     """Full Width Half Max shape paramter in seconds"""
 
-    t0: float = None
+    t0: float = 0.0e+0
     """Center time coordinate of the shape in seconds. Defaults to mid-point of pulse."""
 
     anh: float = -2.1e+8
@@ -513,7 +513,7 @@ class MNIOConnection(Message):
     """
 
     port: int
-    """The physical Tsunami MNIO port, indexed from 0,
+    """The physical Tsunami MNIO port, indexed from 0, 
           where this connection originates."""
 
     destination: str

--- a/rpcq/messages.py
+++ b/rpcq/messages.py
@@ -22,7 +22,7 @@ class ParameterSpec(Message):
     Specification of a dynamic parameter type and array-length.
     """
 
-    type: str = None
+    type: str = ""
     """The parameter type, e.g., one of 'INTEGER', or 'FLOAT'."""
 
     length: int = 1

--- a/rpcq/test/test_spec.py
+++ b/rpcq/test/test_spec.py
@@ -30,7 +30,7 @@ class MyClass(object):
         self.num = num
 
     async def add(self, *args):
-        asyncio.sleep(0.1)
+        await asyncio.sleep(0.1)
         return sum(args) + self.num
 
     def blocking_add(self, *args):

--- a/src/core-messages.lisp
+++ b/src/core-messages.lisp
@@ -157,8 +157,7 @@
    (|t0|
     :documentation "Center time coordinate of the shape in seconds. Defaults to mid-point of pulse."
     :type :float
-    :required t
-    :default nil)
+    :required t)
 
    (|anh|
     :documentation "Anharmonicity of the qubit, f01-f12 in Hz"

--- a/src/core-messages.lisp
+++ b/src/core-messages.lisp
@@ -157,7 +157,8 @@
    (|t0|
     :documentation "Center time coordinate of the shape in seconds. Defaults to mid-point of pulse."
     :type :float
-    :required t)
+    :required t
+    :default 0.0)
 
    (|anh|
     :documentation "Anharmonicity of the qubit, f01-f12 in Hz"

--- a/src/messages.lisp
+++ b/src/messages.lisp
@@ -23,7 +23,7 @@
       :documentation "The parameter type, e.g., one of 'INTEGER', or 'FLOAT'."
       :type :string
       :required t
-      :default nil)
+      :default "")
 
      (|length|
       :documentation "If this is not 1, the parameter is an array of this length."

--- a/src/rpcq.lisp
+++ b/src/rpcq.lisp
@@ -243,7 +243,6 @@ We distinguish between the following options for any field type:
                                  ;; accept a string as the default value for a bytes object
                                  (to-octets default)
                                  (coerce default basic-type)))))
-
        (if required
            (values basic-type coerced-default)
 
@@ -253,8 +252,8 @@ We distinguish between the following options for any field type:
     ;; handle defined message types
     ((symbolp field-type)
      (if required
-         (values `(or null ,field-type) default)
-         (values field-type default)))
+         (values field-type default)
+         (values `(or null ,field-type) default)))
 
     ;; handle lists
     ((eq ':list (car field-type))


### PR DESCRIPTION
Fixes #138, and a python warning.

Providing defaults to slots that are `:required nil` seems odd to me, but that's so widely used in the messages that a "fix" would require a major version bump. Probably not worth it, so just a small band-aid here.