### PR TITLE
Changed reference from ruamel.yaml to ruyaml for compatibility

### DIFF
--- a/rpcq/_base.py
+++ b/rpcq/_base.py
@@ -19,7 +19,7 @@ import sys
 
 import msgpack
 import rapidjson
-from ruamel import yaml
+import ruyaml as yaml
 
 if sys.version_info < (3, 7):
     from rpcq.external.dataclasses import astuple, replace, fields


### PR DESCRIPTION
Running the basic PyQuil functions did not work due to an error in the rpcq package not being able to find the ruamel package, despite installing from source.  Changing to the ruyaml library resolves issues for me using Anaconda on Windows with all latest libraries as of 1/8/2021